### PR TITLE
fix powershell encoding problems for languages other than English

### DIFF
--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -1,3 +1,6 @@
+# fix encoding problems for languages other than English
+$PSDefaultParameterValues['*:Encoding'] = 'utf8'
+
 Function Remove-InvalidFileNameChars {
     param(
         [Parameter(Mandatory = $true,


### PR DESCRIPTION
change default encoding for all cmdlets to UTF8

Microsoft document: about encoding in powershell
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding

A Taiwanese blog about this: (wrote in Chinese)
https://blog.darkthread.net/blog/ps-encoding/