### PR TITLE
Fix: Remove duplicate $PSDefaultParameterValues

### DIFF
--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -1,6 +1,3 @@
-# fix encoding problems for languages other than English
-$PSDefaultParameterValues['*:Encoding'] = 'utf8'
-
 Function Remove-InvalidFileNameChars {
     param(
         [Parameter(Mandatory = $true,


### PR DESCRIPTION
This change does not change any functionality. The duplicate line was accidentally added in #26