### PR TITLE
Enhancement: Add newline between document title and timestamp

### DIFF
--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -221,9 +221,8 @@ Function ProcessSections ($group, $FilePath) {
             }else {
                 $insert1 = "$($page.dateTime)"
                 $insert1 = [Datetime]::ParseExact($insert1, 'yyyy-MM-ddTHH:mm:ss.fffZ', $null)
-                $insert1 = $insert1.ToString("yyyy-MM-dd HH:mm:ss
-                ")
-                $insert2 = "---"
+                $insert1 = $insert1.ToString("`nyyyy-MM-dd HH:mm:ss")
+                $insert2 = "`n---"
                 Set-Content -Path "$($fullfilepathwithoutextension).md" -Value $orig[0..0], $insert1, $insert2, $orig[6..($orig.Count - 1)]
             }
 


### PR DESCRIPTION
So now the document markup should look like:

```
# title

2021-07-30 10:41:56

---

content...
```