### PR TITLE
Enhancement: Add support for Powershell core < 7.1 for Windows

### DIFF
--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -403,7 +403,13 @@ try {
     else { $converter = "markdown" }
 
     # Open OneNote hierarchy
-    $OneNote = New-Object -ComObject OneNote.Application
+    if ($PSVersionTable.PSVersion.Major -le 5) {
+        $OneNote = New-Object -ComObject OneNote.Application
+    }else {
+        # Works between powershell 6.0 and 7.0, but not >= 7.1
+        Add-Type -Path $env:windir\assembly\GAC_MSIL\Microsoft.Office.Interop.OneNote\15.0.0.0__71e9bce111e9429c\Microsoft.Office.Interop.OneNote.dll # -PassThru
+        $OneNote = [Microsoft.Office.Interop.OneNote.ApplicationClass]::new()
+    }
     [xml]$Hierarchy = ""
     $totalerr = ""
     $OneNote.GetHierarchy("", [Microsoft.Office.InterOp.OneNote.HierarchyScope]::hsPages, [ref]$Hierarchy)


### PR DESCRIPTION
Enables the script to be used on Powershell core < 7.1 on Windows. On Powershell core 7.1 or above, the onenote GAC assembly on Windows does not load but fails with error message: `Error HRESULT E_FAIL has been returned from a call to a COM component.`