### PR TITLE
Refactor: Move code into individual functions

### DIFF
--- a/config.example.ps1
+++ b/config.example.ps1
@@ -6,11 +6,11 @@
 #   2) Configure the options below to your liking
 #   3) Run the main script: ./ConvertOneNote2MarkDown-v2.ps1. Sit back while the script starts converting immediately.
 
-# Specify folder path that will contain your resulting Notes structure. ex. 'c:\temp\notes'
+# Specify folder path that will contain your resulting Notes structure - Default: c:\temp\notes
 $notesdestpath = 'c:\temp\notes'
 
 # Specify a notebook name to convert
-# '': Convert all notebooks - Default"
+# '': Convert all notebooks - Default
 # 'mynotebook': Convert specific notebook named 'mynotebook'
 $targetNotebook = ''
 


### PR DESCRIPTION
Related: #33

By breaking down the code into individual functions, the functions are now prepared to be unit tested.

Entrypoint function is now:
- `Convert-OneNote2MarkDown`

Dependency validation is now:
- `Validate-Dependencies`

Configuration is now split into some functions:
- `Get-DefaultConfiguration`
- `New-ConfigurationFile` (not used at the moment, used for generating config.example.ps1)
- `Compile-Configuration`
- `Validate-Configuration`

Configuration is now isolated (configuration is now contained in an`$config` object, instead of using script-scoped variables which clutter the script scope's variable namespace), validated (it is type-checked with a default fallback value), extensible (i.e. adding a configuration options is now in one function), consumable (`$config` can be passed to any function), with a single source of truth based on `Get-DefaultConfiguration` (i.e. the interactive prompt descriptions are identical to the generated config.ps1 config option description comments).

`ProcessSections` now consumes in the `$config` object by a parameter. It populates the `$totalerr` error variable based on `Write-Error` occurrences inside the function.

In summary, `Convert-OneNote2MarkDown` entrypoint just performs:
- Validation of dependencies
- Compilation and validation of configuration into `$config` object
- Conversion of notebooks
- Cleanup and show errors (if any)

The `./ConvertOneNote2MarkDown-v2.ps1` script now accepts [common parameters](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-7.1)