### PR TITLE
Enhancement: Perform conversion configuration and conversion simultaneously

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ The powershell script 'ConvertOneNote2MarkDown-v2.ps1' will utilize the OneNote 
   * Improved file headers, with title now as a # heading, standardized DateTime format, and horizontal line to separate from rest of document
 * Remove double spaces and `\` escape symbol that are created when converting with Pandoc
 * Allow to choose whether to keep spaces in file and folder names (1 space between words, removes preceding and trailing spaces).
+* Detailed logs. Run the script with `-Verbose` to see detailed logs of each page's conversion.
 
 ## Known Issues
 
@@ -92,9 +93,13 @@ Clone this repository to acquire the powershell script.
 
     ```.\ConvertOneNote2MarkDown-v2.ps1```
 
+    * If you would like to see detailed logs about the conversion process, use the `-Verbose` switch:
+
+    ```.\ConvertOneNote2MarkDown-v2.ps1 -Verbose```
+
     * if you have trouble, try running both Onenote and Powershell as an administrator.
     * if you receive an error, try running this line to bypass security:
-     ``Set-ExecutionPolicy Bypass -Scope Process``
+    ``Set-ExecutionPolicy Bypass -Scope Process``
 
 
 1. If you chose to use a configuration file `config.ps1`, skip to the next step. If you did not choose to use a configuration file, the script will ask you for configuration interactively.


### PR DESCRIPTION
Previously in #50, conversion could only start only after waiting for conversion configuration for all notebook(s)' pages to be compiled. The wait could be long for one or more large notebooks.

This change eliminates this delay, allowing conversion to take place as soon as each conversion configuration of a notebook page is built. This is done by creating a pipeline between the conversion config builder function to the conversion function, and sending each conversion object down the pipeline as soon as it is built.

Converting pages should start immediately as soon as the script is run, just like it has been prior to #50.
- Test-run behavior (i.e. user testing out the script with various configs until they find one they like) is now restored.
- Dry-run behavior can very easily be supported. This can help the user discover their desired settings quicker than Test-run.

Logs in `New-SectionGroupConversionConfig` is enhanced for better readability.