### PR TITLE
Revert (configuration): Remove option to choose whether to keep spaces in file and folder names

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -49,7 +49,6 @@ $conversion = 1
 $headerTimestampEnabled = 1
 $keepspaces = 1
 $keepescape = 1
-$keepPathSpaces = 1
 '@
             }
             $expectedConfig = Get-DefaultConfiguration
@@ -92,9 +91,6 @@ $keepPathSpaces = 1
                     value = $null
                 }
                 keepescape = @{
-                    value = $null
-                }
-                keepPathSpaces = @{
                     value = $null
                 }
             }
@@ -861,29 +857,6 @@ foo\bar
                 $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
                 $fakeMarkdownContent.Count | Should -Be 7
                 $fakeMarkdownContent[6] | Should -Match '^foo\\bar\s*$'
-            }
-        }
-
-        It "Should honor config keepPathSpaces" {
-            $params['Config']['keepPathSpaces']['value'] = 1
-
-            $result1 = @( New-SectionGroupConversionConfig @params 6>$null )
-
-            $params['Config']['keepPathSpaces']['value'] = 2
-
-            $result2 = @( New-SectionGroupConversionConfig @params 6>$null )
-
-            # 9 pages from 'test' notebook, 9 pages from 'test2' notebook
-            $result1.Count | Should -Be 18
-            $result2.Count | Should -Be 18
-
-            # Between keepPathSpaces 1 and 2, any difference should be space-related
-            for ($i = 0; $i -lt $result1.Count; $i++) {
-                $result1[$i]['mdFileName'] | Should -Not -Be $result2[$i]['mdFileName']
-                $result1[$i]['fullfilepathwithoutextension'] | Should -Not -Be $result2[$i]['fullfilepathwithoutextension']
-
-                $result2[$i]['mdFileName'].Replace(' ', '-') | Should -Be $result1[$i]['mdFileName']
-                $result2[$i]['fullfilepathwithoutextension'].Replace(' ', '-') | Should -Be $result1[$i]['fullfilepathwithoutextension']
             }
         }
 

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -131,16 +131,6 @@ Whether to clear escape symbols from md files
             value = 1
             validateRange = 1,2
         }
-        keepPathSpaces = @{
-            description = @'
-Whether to replace spaces with dashes i.e. '-' in file and folder names
-1: Replace spaces with dashes in file and folder names - Default
-2: Keep spaces in file and folder names (1 space between words, removes preceding and trailing spaces)"
-'@
-            default = 1
-            value = 1
-            validateRange = 1,2
-        }
     }
 
     $config
@@ -502,7 +492,7 @@ Function New-SectionGroupConversionConfig {
         $cfg = [ordered]@{}
         $cfg['object'] = $sectionGroup # Keep a reference to the SectionGroup object
         $cfg['kind'] = 'SectionGroup'
-        $cfg['nameCompat'] = $sectionGroup.name | Remove-InvalidFileNameChars -KeepPathSpaces:($config['keepPathSpaces']['value'] -eq 2)
+        $cfg['nameCompat'] = $sectionGroup.name | Remove-InvalidFileNameChars
         $cfg['levelsFromRoot'] = $LevelsFromRoot
         $cfg['uri'] = $sectionGroup.path # E.g. https://d.docs.live.net/0123456789abcdef/Skydrive Notebooks/mynotebook/mysectiongroup
         $cfg['notesDirectory'] = [io.path]::combine( $NotesDestination.Replace('\', [io.path]::DirectorySeparatorChar), $cfg['nameCompat'] )
@@ -531,7 +521,7 @@ Function New-SectionGroupConversionConfig {
             $sectionCfg['sectionGroupName'] = $cfg['object'].name
             $sectionCfg['object'] = $section # Keep a reference to the Section object
             $sectionCfg['kind'] = 'Section'
-            $sectionCfg['nameCompat'] = $section.name | Remove-InvalidFileNameChars -KeepPathSpaces:($config['keepPathSpaces']['value'] -eq 2)
+            $sectionCfg['nameCompat'] = $section.name | Remove-InvalidFileNameChars
             $sectionCfg['levelsFromRoot'] = $cfg['levelsFromRoot'] + 1
             $sectionCfg['pathFromRoot'] = "$( $cfg['pathFromRoot'] )$( [io.path]::DirectorySeparatorChar )$( $sectionCfg['nameCompat'] )"
             $sectionCfg['uri'] = $section.path # E.g. https://d.docs.live.net/0123456789abcdef/Skydrive Notebooks/mynotebook/mysectiongroup/mysection
@@ -552,7 +542,7 @@ Function New-SectionGroupConversionConfig {
                 $pageCfg['sectionName'] = $sectionCfg['object'].name
                 $pageCfg['object'] = $page # Keep a reference to my Page object
                 $pageCfg['kind'] = 'Page'
-                $pageCfg['nameCompat'] = $page.name | Remove-InvalidFileNameChars -KeepPathSpaces:($config['keepPathSpaces']['value'] -eq 2)
+                $pageCfg['nameCompat'] = $page.name | Remove-InvalidFileNameChars
                 $pageCfg['levelsFromRoot'] = $sectionCfg['levelsFromRoot']
                 $pageCfg['pathFromRoot'] = "$( $sectionCfg['pathFromRoot'] )$( [io.path]::DirectorySeparatorChar )$( $pageCfg['nameCompat'] )"
                 $pageCfg['uri'] = "$( $sectionCfg['object'].path )/$( $page.name )" # There's no $page.path property, so we generate one. E.g. https://d.docs.live.net/0123456789abcdef/Skydrive Notebooks/mynotebook/mysectiongroup/mysection/mypage
@@ -639,7 +629,7 @@ Function New-SectionGroupConversionConfig {
                             foreach ($i in $insertedFiles) {
                                 $attachmentCfg = [ordered]@{}
                                 $attachmentCfg['object'] =  $i
-                                $attachmentCfg['nameCompat'] =  $i.preferredName | Remove-InvalidFileNameCharsInsertedFiles -KeepPathSpaces:($config['keepPathSpaces']['value'] -eq 2)
+                                $attachmentCfg['nameCompat'] =  $i.preferredName | Remove-InvalidFileNameCharsInsertedFiles
                                 $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'].Replace("$", "\$").Replace("^", "\^").Replace("'", "\'")
                                 $attachmentCfg['source'] =  $i.pathCache
                                 $attachmentCfg['destination'] =  [io.path]::combine( $pageCfg['mediaPath'], $attachmentCfg['nameCompat'] )

--- a/config.example.ps1
+++ b/config.example.ps1
@@ -57,8 +57,3 @@ $keepspaces = 1
 # 1: Clear '\' symbol escape character from files - Default
 # 2: Keep '\' symbol escape
 $keepescape = 1
-
-# Whether to replace spaces with dashes i.e. '-' in file and folder names
-# 1: Replace spaces with dashes in file and folder names - Default
-# 2: Keep spaces in file and folder names (1 space between words, removes preceding and trailing spaces)"
-$keepPathSpaces = 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,6 @@ The powershell script 'ConvertOneNote2MarkDown-v2.ps1' will utilize the OneNote 
 * Allow to choose whether to include page timestamp and a separator at top of document
   * Improved file headers, with title now as a # heading, standardized DateTime format, and horizontal line to separate from rest of document
 * Remove double spaces and `\` escape symbol that are created when converting with Pandoc
-* Allow to choose whether to keep spaces in file and folder names (1 space between words, removes preceding and trailing spaces).
 * Detailed logs. Run the script with `-Verbose` to see detailed logs of each page's conversion.
 
 ## Known Issues


### PR DESCRIPTION
Previously in #36, a configuration option `$keepPathSpaces` was added to control whether to keep spaces in section group, section, and page names in the generated files and folders.

It was identified in #53, that this configuration option will result in an error in pandoc, and has not been working since `v2.10.0`.

Pandoc throws errors when a path with spaces is given  in `-i` or `-o`. A possible workaround would be to normalize those arguments to use dashes instead of spaces, and then rename the final `-o` `.md` file to the original name with spaces.

Although it appears trivial to use the above workaround, it does mean that there would have to be two sets of output directories, one for the `.md` file output by `-o`, and the other for the final renamed file. This introduces complexity in the Page Conversion Configuration object. This is made more complex when the `$medialocation = 2` (where media is created in the same directory as the output `.md` file), such that the media must also be moved to the new location. Because media paths are not part of the Conversion Configuration, because media extraction is done by Pandoc, to move media  to their original location and to replace occurrences of any media path references in the `.md` file content must be done at conversion runtime. This has downsides:
- pollution of the conversion function
- difficult to test

In general, as discussed in https://github.com/theohbrothers/ConvertOneNote2MarkDown/issues/20#issuecomment-888956344, usage of space should be avoided, for the sake of 1) spaces in URIs are actually invalid 2) markdown compatibility issues with spaces in paths 3) A page named '  foo  bar  baz  ' should be expected to retain all spaces, but the expected filename '  foo bar baz  ' is actually invalid, so it would have to be trimmed to be 'foo bar baz', losing essential information in its name. Whereas if we did normalize that page name to use dashes, it would be '--foo-bar-baz--', retaining the whitespaces in the form of '-' and information in its name.

Hence, the default behavior would best be to normalize all spaces in Section Group, Section, and Page names to dashes.