### PR TITLE
Enhancement: Use hierarchy-qualified static unique name for media

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -627,7 +627,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             }
         }
 
-        It "Should constructs individual conversion configuration(s) for pages, based on a given Section Group XML object. Ignores pages in recycle bin." {
+        It "Should construct individual conversion configuration(s) for pages, based on a given Section Group XML object. Ignores pages in recycle bin." {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 9 pages from 'test' notebook, 9 pages from 'test2' notebook
@@ -1076,7 +1076,7 @@ Describe 'Convert-OneNotePage' -Tag 'Unit' {
                     Extension = '.jpg'
                 }
             }
-            Mock Rename-Item {
+            Mock Move-Item {
                 [pscustomobject]@{
                     BaseName = 'somenewname'
                     Name = 'somenewname.jpg'
@@ -1175,11 +1175,11 @@ Describe 'Convert-OneNotePage' -Tag 'Unit' {
             Convert-OneNotePage @params 6>$null
 
             Assert-MockCalled -CommandName Get-ChildItem -Times 1
-            Assert-MockCalled -CommandName Rename-Item -Times 1
+            Assert-MockCalled -CommandName Move-Item -Times 1
         }
 
         It "Does not halt conversion if renaming image(s) fails" {
-            Mock Rename-Item { throw }
+            Mock Move-Item { throw }
 
             $err = Convert-OneNotePage @params 6>$null 2>&1
 
@@ -1213,7 +1213,7 @@ Describe 'Convert-OneNotePage' -Tag 'Unit' {
             Mock Remove-Item { 'foo' }
             Mock Publish-OneNotePageToDocx { 'foo' }
             Mock Start-Process { 'foo' }
-            Mock Rename-Item { 'foo' }
+            Mock Move-Item { 'foo' }
             Mock Get-Content { 'foo' }
             Mock Set-Content { 'foo' }
 

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -891,16 +891,19 @@ Function Convert-OneNotePage {
             }
 
             # Rename images to have unique names - NoteName-Image#-HHmmssff.xyz
-            $timeStamp = (Get-Date -Format HHmmssff).ToString()
-            $timeStamp = $timeStamp.replace(':', '')
             $images = Get-ChildItem -Path "$( $pageCfg['mediaPath'] )" -Include "*.png", "*.gif", "*.jpg", "*.jpeg" -Recurse -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name.SubString(0, 5) -match "image" }
             foreach ($image in $images) {
-                $newimageName = "$($( $pageCfg['mdFileName'] ).SubString(0,[math]::min(30,$( $pageCfg['mdFileName'] ).length)))-$($image.BaseName)-$($timeStamp)$($image.Extension)"
                 # Rename Image
                 try {
-                    "Renaming image: $( $image.FullName ) to $( $newimageName )" | Write-Verbose
+                    $newimageName = if ($config['medialocation']['value'] -eq 2) {
+                        "$( $pageCfg['filePathRelUnderscore'] )-$($image.BaseName)$($image.Extension)"
+                    }else {
+                        "$( $pageCfg['pathFromRootCompat'] )-$($image.BaseName)$($image.Extension)"
+                    }
+                    $newimagePath = [io.path]::combine( $pageCfg['mediaPath'], $newimageName )
+                    "Renaming image: $( $image.FullName ) to $( $newimagePath )" | Write-Verbose
                     if ($config['dryRun']['value'] -eq 1) {
-                        $item = Rename-Item -Path "$( $image.FullName )" -NewName $newimageName -ErrorAction Stop -PassThru
+                        $item = Move-Item -Path "$( $image.FullName )" -Destination $newimagePath -Force -ErrorAction Stop -PassThru
                     }
                 }catch {
                     Write-Error "Error while renaming image $( $image.FullName ) to $( $item.FullName ): $( $_.Exception.Message )"


### PR DESCRIPTION
In all previous versions, media was named in format `<page-name><optional-postfix>-image<image-index>-<unique-timestamp><extension>`, e.g. `hello-world-image1-11223344.png`, and `hello-world-N-image1-11223344.png` for identically-named pages where `N` is incremented. This resulted in unique names for images, regardless of the setting of the `medialocation` configuration option.

However, if a user uses `$medialocation = 1` (i.e. a central `/media` folder), and converts a notebook with many pages with many images, if the notebook happens to contain many similarly-named or identically-named pages, the central `/media` folder can contain a lot of similarly named image names, e.g. `hello-world-image1-11223344.png`, `hello-world-1-1-image1-11223344.png`, where it becomes very difficult to make meaning of or trace a image to the page it belongs.

Now, the image names are named in format: `<hierarchy>-<page-name>-<optional-postfix>-image<image-index>.<extension`. The difference is that instead of using a timestamp suffix, a hierarchy prefix is added. This gives meaning to the image name, while preserving the uniqueness of all image names within the scope of a notebook.

Another benefit of this is that repeated conversion of a notebook can be done against an existing output folder, without creating duplicate images (which was the previous behavior when using a timestamp suffix).

Note that because media is generated at conversion runtime, this feature cannot really be unit tested. The code is straightforward since the naming of the image makes use of a conversion configuration object.