### PR TITLE
Feature (configuration): Add configuration option `newlineCharacter` to choose whether to use LF or CRLF for newlines

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,6 +20,12 @@
                 "isDefault": true,
                 "kind": "test"
             }
+        },
+        {
+            "label": "Generate config.example.ps1",
+            "type": "shell",
+            "command": "pwsh -Command '. ./ConvertOneNote2MarkDown-v2.ps1 -Exit; New-ConfigurationFile'",
+            "group": "build"
         }
     ]
 }

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -141,6 +141,16 @@ Whether to clear escape symbols from md files
             value = 1
             validateRange = 1,2
         }
+        newlineCharacter = @{
+            description = @'
+Whether to use Line Feed (LF) or Carriage Return + Line Feed (CRLF) for new lines - Default
+1: LF (unix) - Default
+2: CRLF (windows) - Default
+'@
+            default = 1
+            value = 1
+            validateRange = 1,2
+        }
     }
 
     $config
@@ -657,7 +667,7 @@ Function New-SectionGroupConversionConfig {
                     }
                 )
                 $pageCfg['mutations'] = @(
-                    # Markdown mutations
+                    # Markdown mutations. Each search and replace is done against a string containing the entire markdown content
 
                     foreach ($attachmentCfg in $pageCfg['insertedAttachments']) {
                         @{
@@ -689,7 +699,7 @@ Function New-SectionGroupConversionConfig {
                                     $heading = "# $( $pageCfg['object'].name )"
                                     if ($config['headerTimestampEnabled']['value'] -eq 1) {
                                         $heading += $pageCfg['dateTime'].ToString("`n`nyyyy-MM-dd HH:mm:ss")
-                                        $heading += "`r`n`r`n---`r`n"
+                                        $heading += "`n`n---`n"
                                     }
                                     $heading
                                 }
@@ -705,8 +715,8 @@ Function New-SectionGroupConversionConfig {
                                     replacement = ''
                                 }
                                 @{
-                                    searchRegex = '\r?\n\r?\n- '
-                                    replacement = "`r`n- "
+                                    searchRegex = '\r*\n\r*\n- '
+                                    replacement = "`n- "
                                 }
                             )
                         }
@@ -720,6 +730,29 @@ Function New-SectionGroupConversionConfig {
                                     replacement = ''
                                 }
                             )
+                        }
+                    }
+                    & {
+                        if ($config['newlineCharacter']['value'] -eq 1) {
+                            @{
+                                description = "Use LF for newlines"
+                                replacements = @(
+                                    @{
+                                        searchRegex = '\r*\n'
+                                        replacement = "`n"
+                                    }
+                                )
+                            }
+                        }else {
+                            @{
+                                description = "Use CRLF for newlines"
+                                replacements = @(
+                                    @{
+                                        searchRegex = '`r*\n'
+                                        replacement = "`r`n"
+                                    }
+                                )
+                            }
                         }
                     }
                 )
@@ -934,7 +967,7 @@ Function Convert-OneNotePage {
                             # Empty page
                             ''
                         }
-                    ) -join "`r`n"
+                    ) -join "`n"
                 }
 
                 # Mutate

--- a/config.example.ps1
+++ b/config.example.ps1
@@ -62,3 +62,8 @@ $keepspaces = 1
 # 1: Clear '\' symbol escape character from files - Default
 # 2: Keep '\' symbol escape
 $keepescape = 1
+
+# Whether to use Line Feed (LF) or Carriage Return + Line Feed (CRLF) for new lines - Default
+# 1: LF (unix) - Default
+# 2: CRLF (windows) - Default
+$newlineCharacter = 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ The powershell script 'ConvertOneNote2MarkDown-v2.ps1' will utilize the OneNote 
   * Improved headers, with title now as a # heading, standardized DateTime format, and horizontal line to separate from rest of document
 * Allows to choose whether to remove double spaces between bullet points and non-breaking spaces that are created when converting with Pandoc
 * Allows to choose whether to remove `\` escape symbol that are created when converting with Pandoc
+* Allows to choose whether to use Line Feed (LF) or Carriage Return + Line Feed (CRLF) for new lines
 * Allows Detailed logging. Run the script with `-Verbose` to see detailed logs of each page's conversion.
 
 ## Known Issues


### PR DESCRIPTION
This feature enables a user to choose whether to use Line Feed (`LF`) or Carriage Return + Line Feed (`CRLF`) for newlines in `.md` files. This is especially useful when performing conversion against a notes destination folder which is `git` controlled, such that the generated `.md` do not appear in `git diff` as a result of newline diffs.

The default behavior is to use `LF`.