### PR TITLE
Enhancement: Fallback on default configuration for missing options in configuration file `config.ps1`

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,6 +26,18 @@
             "type": "shell",
             "command": "pwsh -Command '. ./ConvertOneNote2MarkDown-v2.ps1 -Exit; New-ConfigurationFile'",
             "group": "build"
+        },
+        {
+            "label": "Convert",
+            "type": "shell",
+            "command": "pwsh -Command '. ./ConvertOneNote2MarkDown-v2.ps1'",
+            "group": "none"
+        },
+        {
+            "label": "Convert (verbose)",
+            "type": "shell",
+            "command": "pwsh -Command '. ./ConvertOneNote2MarkDown-v2.ps1 -Verbose'",
+            "group": "none"
         }
     ]
 }

--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -35,15 +35,16 @@ Describe "Compile-Configuration" -Tag 'Unit' {
 
     Context 'Behavior' {
 
-        It "Compiles configuration from config file: normalize path, trim string" {
+        It "Compiles configuration from config file: cast input as expected type, normalize path, trim string, and fallback on default values on empty input" {
             Mock Test-Path { $true }
             Mock Get-Content {
+                # Fake content of a config.ps1
                 @'
 $dryrun = 1
 $notesdestpath = 'c:\temp\notes\/ ' # Deliberately add a trailing slah(es) and space
 $targetNotebook = '   ' # Deliberately add extra spaces
-$usedocx = 1
-$keepdocx = 1
+$usedocx = '1'
+# $keepdocx = 1 # Deliberately omit a configuration option from
 $prefixFolders = 1
 $medialocation = 1
 $conversion = 1
@@ -108,7 +109,13 @@ Describe "Validate-Configuration" -Tag 'Unit' {
     Context 'Behavior' {
 
         It "Throws on missing config option" {
-            $config = @{}
+            $config = Get-DefaultConfiguration
+            $config['notesdestpath'] = $null
+
+            { $config | Validate-Configuration } | Should -Throw 'Missing configuration option'
+
+            $config = Get-DefaultConfiguration
+            $config['notesdestpath']['value'] = $null
 
             { $config | Validate-Configuration } | Should -Throw 'Missing configuration option'
         }


### PR DESCRIPTION
Since `v2.10.0`, if a `config.ps1` file failed to contain a required configuration option, there would be a terminating error.

Now, missing options in `config.ps1` will fallback on their default value.

This ensures that if a user uses an older `config.ps1` with certain missing newer configuration options, the conversion carries on assuming defaults for those options.