### PR TITLE
Fix: Fix inserted attachment names not being markdown-encoded in final markdown

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -216,7 +216,6 @@ Describe "Remove-InvalidFileNameChars" -Tag 'Unit' {
             $fileName = 'foo'
 
             { $fileName | Remove-InvalidFileNameChars } | Should -Not -Throw
-
         }
 
     }
@@ -289,7 +288,6 @@ Describe "Remove-InvalidFileNameCharsInsertedFiles" -Tag 'Unit' {
             $fileName = 'foo'
 
             { $fileName | Remove-InvalidFileNameCharsInsertedFiles } | Should -Not -Throw
-
         }
 
     }
@@ -330,6 +328,34 @@ Describe "Remove-InvalidFileNameCharsInsertedFiles" -Tag 'Unit' {
             $result = Remove-InvalidFileNameCharsInsertedFiles -Name $fileName -KeepPathSpaces
 
             $result | Should -Be $expectedFileName
+        }
+
+    }
+
+}
+
+
+Describe "Encode-Markdown" -Tag 'Unit' {
+
+    Context 'Parameters' {
+
+        It "Accept pipeline input" {
+            $content = 'foo'
+
+            { $content | Encode-Markdown } | Should -Not -Throw
+        }
+
+    }
+
+    Context 'Behavior' {
+
+        It "Should encode given content in markdown" {
+            $content = '\*_{}[]()#+-.!`'
+            $expectedContent = '\\\*\_\{\}\[\]\(\)\#\+\-\.\!```'
+
+            $result = Encode-Markdown -Name $content
+
+            $result | Should -Be $expectedContent
         }
 
     }
@@ -636,10 +662,10 @@ AAAAAElFTkSuQmCC</one:Data>
                 <one:T selected="all"><![CDATA[Attachments:]]></one:T>
             </one:OE>
             <one:OE creationTime="2021-08-06T16:08:25.000Z" lastModifiedTime="2021-08-06T16:08:25.000Z" objectID="{902AD630-91B7-4D8B-96A7-107572724072}{49}{B0}" selected="all" alignment="left">
-                <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment1.txt" preferredName="attachment1.txt" />
+                <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment1(something in brackets).txt" preferredName="attachment1(something in brackets).txt" />
             </one:OE>
             <one:OE creationTime="2021-08-06T16:08:10.000Z" lastModifiedTime="2021-08-06T16:08:10.000Z" objectID="{902AD630-91B7-4D8B-96A7-107572724072}{41}{B0}" selected="all" alignment="left">
-                <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment2.txt" preferredName="attachment2.txt" />
+                <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment2[something in brackets].txt" preferredName="attachment2(something in brackets).txt" />
             </one:OE>
         </one:OEChildren>
     </one:Outline>
@@ -711,6 +737,20 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
 
                 # Test the first level page preceded by a second level page
                 $pageCfg5['pagePrefix'] | Should -Be ''
+            }
+        }
+
+        It "Should determine attachment references correctly" {
+            $result = @( New-SectionGroupConversionConfig @params 6>$null )
+
+            # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
+            $result.Count | Should -Be 30
+
+            foreach ($pageCfg in $result) {
+                $pageCfg['insertedAttachments'].Count | Should -Be 2
+
+                $pageCfg['insertedAttachments'][0]['markdownFileName'] | Should -Be 'attachment1\(something\-in\-brackets\)\.txt'
+                $pageCfg['insertedAttachments'][1]['markdownFileName'] | Should -Be 'attachment2\(something\-in\-brackets\)\.txt'
             }
         }
 

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -379,6 +379,24 @@ Function Remove-InvalidFileNameCharsInsertedFiles {
     return $newName
 }
 
+Function Encode-Markdown {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true,Position = 0,ValueFromPipeline = $true,ValueFromPipelineByPropertyName = $true)]
+        [AllowEmptyString()]
+        [string]$Name
+    )
+
+    $markdownChars = '\*_{}[]()#+-.!'.ToCharArray()
+    foreach ($c in $markdownChars) {
+        $Name = $Name.Replace("$c", "\$c")
+    }
+    $markdownChars2 = '`'
+    foreach ($c in $markdownChars2) {
+        $Name = $Name.Replace("$c", "$c$c$c")
+    }
+    $Name
+}
 Function New-OneNoteConnection {
     [CmdletBinding()]
     param ()
@@ -674,7 +692,7 @@ Function New-SectionGroupConversionConfig {
                                             $attachmentCfg = [ordered]@{}
                                             $attachmentCfg['object'] =  $i
                                             $attachmentCfg['nameCompat'] =  $i.preferredName | Remove-InvalidFileNameCharsInsertedFiles
-                                            $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'].Replace("$", "\$").Replace("^", "\^").Replace("'", "\'")
+                                            $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'] | Encode-Markdown
                                             $attachmentCfg['source'] =  $i.pathCache
                                             $attachmentCfg['destination'] =  [io.path]::combine( $pageCfg['mediaPath'], $attachmentCfg['nameCompat'] )
 


### PR DESCRIPTION
This bug affects all previous versions.

Previously, if an attachment name contains any of the following characters:

```
*_{}[]()#+-.!`
```

then the reference of the attachment in markdown becomes unrecognized by markdown previewers because those characters are not markdown-escaped (i.e. interpreted as markdown) when the name of the reference is injected into the markdown during the conversion.

Now, these characters are markdown-encoded, and references of attachments are now valid and interpretable by markdown previewers.