### PR TITLE
Enhancement: Improve conversion speed for notebooks containing many media files

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -821,21 +821,24 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result.Count | Should -Be 30
 
             # Test the first object
-            $regex = "^$( [regex]::Escape($params['Config']['notesdestpath']['value']) )"
-            $regexPandoc = "^$( [regex]::Escape($params['Config']['notesdestpath']['value'].Replace([io.path]::DirectorySeparatorChar, '/')) )"
             $pageCfg = $result[0]
+            $regex = "^$( [regex]::Escape($params['Config']['notesdestpath']['value']) )"
+            $regexTmp = "^$( [regex]::Escape($pageCfg['tmpPath']) )"
             $pageCfg['fullexportdirpath'] | Should -Match $regex
             $pageCfg['fullfilepathwithoutextension'] | Should -Match $regex
             $pageCfg['mediaParentPath'] | Should -Match $regex
             $pageCfg['mediaPath'] | Should -Match $regex
-            $pageCfg['mediaParentPathPandoc'] | Should -Match $regexPandoc
-            $pageCfg['mediaPathPandoc'] | Should -Match $regexPandoc
+            $pageCfg['mediaParentPathPandoc'] | Should -Be $pageCfg['tmpPath'].Replace([io.path]::DirectorySeparatorChar, '/')
+            $pageCfg['mediaPathPandoc'] | Should -Be $( [io.path]::combine($pageCfg['tmpPath'], 'media').Replace([io.path]::DirectorySeparatorChar, '/') )
             $pageCfg['fullexportpath'] | Should -Match $regex
             $pageCfg['insertedAttachments'] | ForEach-Object {
                 $_['destination'] | Should -Match $regex
             }
             $pageCfg['directoriesToCreate'] | ForEach-Object {
-                $_ | Should -Match $regex
+                ($_ -match $regex) -or ($_ -match $regexTmp) | Should -Be $true
+            }
+            $pageCfg['directoriesToDelete'] | ForEach-Object {
+                $_ | Should -Match $regexTmp
             }
         }
 


### PR DESCRIPTION
Previously, when renaming files to unique names, conversion function looked in the `/media` directory for images (`Get-ChildItem`) with basename starting with `image`. However, as the number of files in the `/media` grows, conversion slows.

Now, pandoc converts is made to extract media into a unique temp media folder, and the conversion function looks in that folder for images with basename starting with `image`. This temp media folder will only ever contain the media specific to the converted page, and hence `Get-ChildItem` stays performant.

This temp folder will be empty at each conversion, and will not be deleted, for safety reasons (`Remove-Item -Recurse` is a dangerous command).

In addition, `-Verbose` now shows markdown mutation's regexes and replacements.