### PR TITLE
Enhancement: Prettify attachment references by only markdown-encoding brackets

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -349,11 +349,19 @@ Describe "Encode-Markdown" -Tag 'Unit' {
 
     Context 'Behavior' {
 
-        It "Should encode given content in markdown" {
-            $content = '\*_{}[]()#+-.!`'
+        $content = '\*_{}[]()#+-.!`'
+        It "Should markdown-encode given content" {
             $expectedContent = '\\\*\_\{\}\[\]\(\)\#\+\-\.\!```'
 
             $result = Encode-Markdown -Name $content
+
+            $result | Should -Be $expectedContent
+        }
+
+        It "Should markdown-encode given content (URIs)" {
+            $expectedContent = '\*_{}\[\]\(\)#+-.!`'
+
+            $result = Encode-Markdown -Name $content -Uri
 
             $result | Should -Be $expectedContent
         }
@@ -749,8 +757,8 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             foreach ($pageCfg in $result) {
                 $pageCfg['insertedAttachments'].Count | Should -Be 2
 
-                $pageCfg['insertedAttachments'][0]['markdownFileName'] | Should -Be 'attachment1\(something\-in\-brackets\)\.txt'
-                $pageCfg['insertedAttachments'][1]['markdownFileName'] | Should -Be 'attachment2\(something\-in\-brackets\)\.txt'
+                $pageCfg['insertedAttachments'][0]['markdownFileName'] | Should -Be 'attachment1\(something-in-brackets\).txt'
+                $pageCfg['insertedAttachments'][1]['markdownFileName'] | Should -Be 'attachment2\(something-in-brackets\).txt'
             }
         }
 

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -394,16 +394,28 @@ Function Encode-Markdown {
     param (
         [Parameter(Mandatory = $true,Position = 0,ValueFromPipeline = $true,ValueFromPipelineByPropertyName = $true)]
         [AllowEmptyString()]
-        [string]$Name
+        [string]
+        $Name
+    ,
+        [Parameter()]
+        [switch]
+        $Uri
     )
 
-    $markdownChars = '\*_{}[]()#+-.!'.ToCharArray()
-    foreach ($c in $markdownChars) {
-        $Name = $Name.Replace("$c", "\$c")
-    }
-    $markdownChars2 = '`'
-    foreach ($c in $markdownChars2) {
-        $Name = $Name.Replace("$c", "$c$c$c")
+    if ($Uri) {
+        $markdownChars = '[]()'.ToCharArray()
+        foreach ($c in $markdownChars) {
+            $Name = $Name.Replace("$c", "\$c")
+        }
+    }else {
+        $markdownChars = '\*_{}[]()#+-.!'.ToCharArray()
+        foreach ($c in $markdownChars) {
+            $Name = $Name.Replace("$c", "\$c")
+        }
+        $markdownChars2 = '`'
+        foreach ($c in $markdownChars2) {
+            $Name = $Name.Replace("$c", "$c$c$c")
+        }
     }
     $Name
 }
@@ -751,7 +763,7 @@ Function New-SectionGroupConversionConfig {
                                             $attachmentCfg = [ordered]@{}
                                             $attachmentCfg['object'] =  $i
                                             $attachmentCfg['nameCompat'] =  $i.preferredName | Remove-InvalidFileNameCharsInsertedFiles
-                                            $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'] | Encode-Markdown
+                                            $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'] | Encode-Markdown -Uri
                                             $attachmentCfg['source'] =  $i.pathCache
                                             $attachmentCfg['destination'] =  [io.path]::combine( $pageCfg['mediaPath'], $attachmentCfg['nameCompat'] )
 


### PR DESCRIPTION
Generally, most markdown formats do not require `.` and `-` to be escaped when they are in a URI. This keeps URIs pretty.