### PR TITLE
Refactor (ci): Reenable publish-draft-release job in github workflows

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -124,15 +124,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # publish-draft-release:
-  #   needs: [test-powershell-5-1-windows-2016, test-powershell-5-1-windows-2019, test-powershell-6-0, test-powershell-6-1, test-powershell-6-1, test-powershell-7-0, test-powershell-7-1, test-powershell-7-2]
-  #   if: startsWith(github.ref, 'refs/tags/')
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - id: release-drafter
-  #     uses: release-drafter/release-drafter@v5
-  #     with:
-  #       # config-name: release-drafter.yaml
-  #       publish: true
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-draft-release:
+    needs: [test-powershell-5-1-windows-2016, test-powershell-5-1-windows-2019, test-powershell-6-0, test-powershell-6-1, test-powershell-6-1, test-powershell-7-0, test-powershell-7-1, test-powershell-7-2]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+    - id: release-drafter
+      uses: release-drafter/release-drafter@v5
+      with:
+        # config-name: release-drafter.yaml
+        publish: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reenable auto-releases now that backports should not be required.