### PR TITLE
Enhancement: Remove isolated occurrences of '>' in bullet lists

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -1061,6 +1061,10 @@ hello world $( [char]0x00A0 )
 - foo
 
 - bar
+
+>
+
+some other text
 "@
 
                 # Mutate
@@ -1072,10 +1076,12 @@ hello world $( [char]0x00A0 )
 
                 # Should remove newlines between bullets, and remove non-breaking spaces. Ignore first 8 lines for page header
                 $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 11
+                $fakeMarkdownContent.Count | Should -Be 13
                 $fakeMarkdownContent[8] | Should -Not -Match [char]0x00A0
                 $fakeMarkdownContent[9] | Should -Match '^- foo\s*$'
                 $fakeMarkdownContent[10] | Should -Match '^- bar\s*$'
+                $fakeMarkdownContent[11] | Should -Match '^$'
+                $fakeMarkdownContent[12] | Should -Match '^some other text$'
             }
 
             $params['Config']['keepspaces']['value'] = 2

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -822,9 +822,15 @@ Function New-SectionGroupConversionConfig {
                                             searchRegex = [regex]::Escape([char]0x00A0)
                                             replacement = ''
                                         }
+                                        # Remove a newline between each occurrence of '- some list item'
                                         @{
                                             searchRegex = '\r*\n\r*\n- '
                                             replacement = "`n- "
+                                        }
+                                        # Removes isolated '>' instances with nothing to its right
+                                        @{
+                                            searchRegex = '\r*\n\r*\n>\s*\n'
+                                            replacement = "`n`n"
                                         }
                                     )
                                 }


### PR DESCRIPTION
It is very common to have an "empty bullet point" in a onenote bullet list. This results in the conversion leaving isolated `>` in markdown.

E.g.

```
My list:
- foo

- bar

>

```

`>` in markdown represents a quote, and so this element should be removed.

Now, this mutation is part of the configuration option `$keepspaces = 1` (default behavior)