### PR TITLE
Enhancement: Enhance configuration option `keepescape` to support removing backslashes that precede non-alphanumeric characters

### DIFF
--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -144,8 +144,9 @@ Whether to clear double spaces between bullets
         keepescape = @{
             description = @'
 Whether to clear escape symbols from md files
-1: Clear '\' symbol escape character from files - Default
-2: Keep '\' symbol escape
+1: Clear all '\' characters  - Default
+2: Clear all '\' characters except those preceding alphanumeric characters
+3: Keep '\' symbol escape
 '@
             default = 1
             value = 1
@@ -837,11 +838,22 @@ Function New-SectionGroupConversionConfig {
                             }
                             if ($config['keepescape']['value'] -eq 1) {
                                 @{
-                                    description = 'Clear backslash escape symbols'
+                                    description = "Clear all '\' characters"
                                     replacements = @(
                                         @{
                                             searchRegex = [regex]::Escape('\')
                                             replacement = ''
+                                        }
+                                    )
+                                }
+                            }
+                            elseif ($config['keepescape']['value'] -eq 2) {
+                                @{
+                                    description = "Clear all '\' characters except those preceding alphanumeric characters"
+                                    replacements = @(
+                                        @{
+                                            searchRegex = '\\([^A-Za-z0-9])'
+                                            replacement = '$1'
                                         }
                                     )
                                 }

--- a/config.example.ps1
+++ b/config.example.ps1
@@ -64,8 +64,9 @@ $headerTimestampEnabled = 1
 $keepspaces = 1
 
 # Whether to clear escape symbols from md files
-# 1: Clear '\' symbol escape character from files - Default
-# 2: Keep '\' symbol escape
+# 1: Clear all '\' characters  - Default
+# 2: Clear all '\' characters except those preceding alphanumeric characters
+# 3: Keep '\' symbol escape
 $keepescape = 1
 
 # Whether to use Line Feed (LF) or Carriage Return + Line Feed (CRLF) for new lines


### PR DESCRIPTION
This preserves backslashes in meaningful places, e.g. Windows paths, isolated backslashes, random backslashes used by the user.