### PR TITLE
Enhancement: Remove all '>' occurrences immediately following bullet lists

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -994,6 +994,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result.Count | Should -Be 30
 
             foreach ($pageCfg in $result) {
+                # The first line will be replaced by page header (8 lines)
                 $fakeMarkdownContent = ''
 
                 # Mutate
@@ -1054,34 +1055,40 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
             $result.Count | Should -Be 30
 
-            foreach ($pageCfg in $result) {
-                $fakeMarkdownContent = @"
+            # The first line will be replaced by page header (8 lines)
+            $fakeMarkdownContent = @"
 
-hello world $( [char]0x00A0 )
+hello world$( [char]0x00A0 )
 - foo
 
 - bar
 
 >
+>
+> some other text
+"@ -replace "`r", '' # On some Windows Powershell 5 versions, a here-string will contain `\r`, so let's ensure that doesn't happen.
 
-some other text
-"@
-
+            foreach ($pageCfg in $result) {
                 # Mutate
+                $mutated = $fakeMarkdownContent
                 foreach ($m in $pageCfg['mutations']) {
                     foreach ($r in $m['replacements']) {
-                        $fakeMarkdownContent = $fakeMarkdownContent -replace $r['searchRegex'], $r['replacement']
+                        $mutated = $mutated -replace $r['searchRegex'], $r['replacement']
                     }
                 }
 
                 # Should remove newlines between bullets, and remove non-breaking spaces. Ignore first 8 lines for page header
-                $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 13
-                $fakeMarkdownContent[8] | Should -Not -Match [char]0x00A0
-                $fakeMarkdownContent[9] | Should -Match '^- foo\s*$'
-                $fakeMarkdownContent[10] | Should -Match '^- bar\s*$'
-                $fakeMarkdownContent[11] | Should -Match '^$'
-                $fakeMarkdownContent[12] | Should -Match '^some other text$'
+                $split = $mutated -split "`n"
+                $expectedBody = $split[8..($split.Count - 1)] -join "`n"
+                $expectedBody | Should -Be $( @"
+hello world
+- foo
+- bar
+
+
+
+some other text
+"@ -replace "`r", '') # On some Windows Powershell 5 versions, a here-string will contain `\r`, so let's ensure that doesn't happen.
             }
 
             $params['Config']['keepspaces']['value'] = 2
@@ -1092,28 +1099,27 @@ some other text
             $result.Count | Should -Be 30
 
             foreach ($pageCfg in $result) {
-                $fakeMarkdownContent = @"
-
-hello world $( [char]0x00A0 )
-- foo
-
-- bar
-"@
-
                 # Mutate
+                $mutated = $fakeMarkdownContent
                 foreach ($m in $pageCfg['mutations']) {
                     foreach ($r in $m['replacements']) {
-                        $fakeMarkdownContent = $fakeMarkdownContent -replace $r['searchRegex'], $r['replacement']
+                        $mutated = $mutated -replace $r['searchRegex'], $r['replacement']
                     }
                 }
 
                 # Should keep newlines between bullets, and keep non-breaking spaces. Ignore first 8 lines for page header
-                $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 12
-                $fakeMarkdownContent[8] | Should -Not -Match [char]0x00A0
-                $fakeMarkdownContent[9] | Should -Match '^- foo\s*$'
-                $fakeMarkdownContent[10] | Should -Match '^\s*$'
-                $fakeMarkdownContent[11] | Should -Match '^- bar\s*$'
+                $split = $mutated -split "`n"
+                $expectedBody = $split[8..($split.Count - 1)] -join "`n"
+                $expectedBody | Should -Be $( @"
+hello world$( [char]0x00A0 )
+- foo
+
+- bar
+
+>
+>
+> some other text
+"@ -replace "`r", '') # On some Windows Powershell 5 versions, a here-string will contain `\r`, so let's ensure that doesn't happen.
             }
 
         }
@@ -1127,6 +1133,7 @@ hello world $( [char]0x00A0 )
             $result.Count | Should -Be 30
 
             foreach ($pageCfg in $result) {
+                # The first line will be replaced by page header (8 lines)
                 $fakeMarkdownContent = @"
 
 hello\$\^\\\*\_\[\]world
@@ -1154,6 +1161,7 @@ foo\bar\0
             $result.Count | Should -Be 30
 
             foreach ($pageCfg in $result) {
+                # The first line will be replaced by page header (8 lines)
                 $fakeMarkdownContent = @'
 
 hello\$\^\\\*\_\[\]world
@@ -1182,6 +1190,7 @@ foo\bar\0
             $result.Count | Should -Be 30
 
             foreach ($pageCfg in $result) {
+                # The first line will be replaced by page header (8 lines)
                 $fakeMarkdownContent = @'
 
 hello\$\^\\\*\_\[\]world
@@ -1212,6 +1221,7 @@ foo\bar\0
             $result.Count | Should -Be 30
 
             foreach ($pageCfg in $result) {
+                # The first line will be replaced by page header (8 lines)
                 $fakeMarkdownContent = @"
 
 foo`r`nbar`r`nbaz
@@ -1240,6 +1250,7 @@ foo`r`nbar`r`nbaz
             $result.Count | Should -Be 30
 
             foreach ($pageCfg in $result) {
+                # The first line will be replaced by page header (8 lines)
                $fakeMarkdownContent = @"
 
 foo`r`nbar`r`nbaz

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -133,7 +133,7 @@ Whether to include page timestamp and separator at top of document
         }
         keepspaces = @{
             description = @'
-Whether to clear double spaces between bullets
+Whether to clear double spaces between bullets, non-breaking spaces from blank lines, and '>` after bullet lists
 1: Clear double spaces in bullets - Default
 2: Keep double spaces
 '@
@@ -828,10 +828,10 @@ Function New-SectionGroupConversionConfig {
                                             searchRegex = '\r*\n\r*\n- '
                                             replacement = "`n- "
                                         }
-                                        # Removes isolated '>' instances with nothing to its right
+                                        # Remove all '>' occurrences immediately following bullet lists
                                         @{
-                                            searchRegex = '\r*\n\r*\n>\s*\n'
-                                            replacement = "`n`n"
+                                            searchRegex = '\n>[ ]*'
+                                            replacement = "`n"
                                         }
                                     )
                                 }

--- a/config.example.ps1
+++ b/config.example.ps1
@@ -58,7 +58,7 @@ $conversion = 1
 # 2: Don't include
 $headerTimestampEnabled = 1
 
-# Whether to clear double spaces between bullets
+# Whether to clear double spaces between bullets, non-breaking spaces from blank lines, and '>` after bullet lists
 # 1: Clear double spaces in bullets - Default
 # 2: Keep double spaces
 $keepspaces = 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ The powershell script `ConvertOneNote2MarkDown-v2.ps1` will utilize the OneNote 
    * markdown_strict (original unextended Markdown)
 * Allows to choose whether to include page timestamp and a separator at top of page
   * Improved headers, with title now as a # heading, standardized DateTime format for created and modified dates, and horizontal line to separate from rest of document
-* Allows to choose whether to remove double spaces between bullet points and non-breaking spaces that are created when converting with Pandoc
+* Allows to choose whether to remove double spaces between bullet points, non-breaking spaces from blank lines, and `>` after bullet lists, which are created when converting with Pandoc
 * Allows to choose whether to remove `\` escape symbol that are created when converting with Pandoc
 * Allows to choose whether to use Line Feed (LF) or Carriage Return + Line Feed (CRLF) for new lines
 * Allows Detailed logging. Run the script with `-Verbose` to see detailed logs of each page's conversion.


### PR DESCRIPTION
Enhances #83.

`>` occurences can appear even for non-bullet list items immediately following an "empty bullet" at the end of a bullet list of a onenote page.

Now `> ` occurrences at the start of each line are stripped.