### PR TITLE
Enhancement: Support specifying Pandoc output format and extensions in `conversion` configuration option

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -47,7 +47,7 @@ $usedocx = '1'
 # $keepdocx = 1 # Deliberately omit a configuration option from
 $prefixFolders = 1
 $medialocation = 1
-$conversion = 1
+$conversion = 'markdown-simple_tables-multiline_tables-grid_tables+pipe_tables' # Default
 $headerTimestampEnabled = 1
 $keepspaces = 1
 $keepescape = 1
@@ -149,24 +149,6 @@ Describe "Validate-Configuration" -Tag 'Unit' {
                 $config = Get-DefaultConfiguration
                 Mock Test-Path { $true }
                 $config['usedocx']['value'] = $_
-
-                { $config | Validate-Configuration } | Should -Throw 'The value must be between'
-            }
-
-            # Valid
-            1..6 | % {
-                $config = Get-DefaultConfiguration
-                Mock Test-Path { $true }
-                $config['conversion']['value'] = $_
-
-                { $config | Validate-Configuration } | Should -Not -Throw
-            }
-
-            # Invalid
-            0,7 | % {
-                $config = Get-DefaultConfiguration
-                Mock Test-Path { $true }
-                $config['conversion']['value'] = $_
 
                 { $config | Validate-Configuration } | Should -Throw 'The value must be between'
             }
@@ -1064,6 +1046,19 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
 
             foreach ($pageCfg in $result) {
                 $pageCfg['mediaParentPath'] | Should -Be $pageCfg['fileDirectory']
+            }
+        }
+
+        It "Should honor config conversion" {
+            $params['Config']['conversion']['value'] = 'gfm+pipe_tables'
+
+            $result = @( New-SectionGroupConversionConfig @params 6>$null )
+
+            # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
+            $result.Count | Should -Be 30
+
+            foreach ($pageCfg in $result) {
+                $pageCfg['conversion'] | Should -Be $params['Config']['conversion']['value']
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The powershell script `ConvertOneNote2MarkDown-v2.ps1` will utilize the OneNote 
 * Allows to choose between **discarding or keeping intermediate Word files**. Intermediate Word files are stored in a central notebook folder.
 * Allows to choose between converting from existing `.docx` (90% faster) and creating new ones - useful if just want to test differences in the various processing options without generating new `.docx`each time
 * Allows to choose between naming `.docx` files using page ID and last modified epoch date e.g. `{somelongid}-1234567890.docx` or hierarchy e.g. `<sectiongroup>-<section>-<page>.docx`
-* Allows to **select which markdown format will be used**, defaulting to Pandoc's standard format, which strips any HTML from tables along with other desirable (for me) formatting choices. See more details on these options here: https://pandoc.org/MANUAL.html#options
+* Allows to **specify Pandoc output format and any optional extensions**, defaulting to Pandoc Markdown format which strips most HTML from tables and using pipe tables. See more details on these options here: https://pandoc.org/MANUAL.html#options
    * markdown (Pandoc’s Markdown)
    * commonmark (CommonMark Markdown)
    * gfm (GitHub-Flavored Markdown), or the deprecated and less accurate markdown_github; use markdown_github only if you need extensions not supported in gfm.

--- a/config.example.ps1
+++ b/config.example.ps1
@@ -44,14 +44,17 @@ $prefixFolders = 1
 # 2: Separate 'media' folder for each folder in the hierarchy
 $medialocation = 1
 
-# Specify conversion type
-# 1: markdown (Pandoc) - Default
-# 2: commonmark (CommonMark Markdown)
-# 3: gfm (GitHub-Flavored Markdown)
-# 4: markdown_mmd (MultiMarkdown)
-# 5: markdown_phpextra (PHP Markdown Extra)
-# 6: markdown_strict (original unextended Markdown)
-$conversion = 1
+# Specify Pandoc output format and optional extensions in the format: <format><+extension><-extension>. See: https://pandoc.org/MANUAL.html#options
+# Examples:
+#   markdown-simple_tables-multiline_tables-grid_tables+pipe_tables
+#   commonmark+pipe_tables
+#   gfm+pipe_tables
+#   markdown_mmd-simple_tables-multiline_tables-grid_tables+pipe_tables
+#   markdown_phpextra-simple_tables-multiline_tables-grid_tables+pipe_tables
+#   markdown_strict+simple_tables-multiline_tables-grid_tables+pipe_tables
+# Default:
+#   markdown-simple_tables-multiline_tables-grid_tables+pipe_tables
+$conversion = 'markdown-simple_tables-multiline_tables-grid_tables+pipe_tables'
 
 # Whether to include page timestamp and separator at top of document
 # 1: Include - Default
@@ -63,7 +66,7 @@ $headerTimestampEnabled = 1
 # 2: Keep double spaces
 $keepspaces = 1
 
-# Whether to clear escape symbols from md files
+# Whether to clear escape symbols from md files. See: https://pandoc.org/MANUAL.html#backslash-escapes
 # 1: Clear all '\' characters  - Default
 # 2: Clear all '\' characters except those preceding alphanumeric characters
 # 3: Keep '\' symbol escape


### PR DESCRIPTION
Previously, the `conversion` configuration option did not allow the user to specify any extensions. All output formats other than `markdown` (i.e. Pandoc Markdown) failed with an error (E.g. `The extension simple_tables is not supported for gfm`) because the extensions was hardcoded to be `-simple_tables-multiline_tables-grid_tables+pipe_tables`.

Now, the `conversion` configuration option is a string variable accepting the argument to `pandoc` `-t` flag specifying the Pandoc output format and any optional extensions (See: https://pandoc.org/MANUAL.html#general-options). The default is Pandoc Markdown with pipe tables: `markdown-simple_tables-multiline_tables-grid_tables+pipe_tables` 