### PR TITLE
Fix: Fix bug where backtick characters at end of lines were removed when using CRLF for newlines i.e. `newlineCharacter = 2`

### DIFF
--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -943,7 +943,7 @@ Function New-SectionGroupConversionConfig {
                                         description = "Use CRLF for newlines"
                                         replacements = @(
                                             @{
-                                                searchRegex = '`r*\n'
+                                                searchRegex = '\r*\n'
                                                 replacement = "`r`n"
                                             }
                                         )


### PR DESCRIPTION
A bug in the regular expression stripped out trailing backticks `` ` `` when using CRLF for newlines i.e. `newlineCharacter = 2`. This could have broken fenced codeblocks.