### PR TITLE
Enhancement (logs): Output script exception and stack trace to error stream and show any configuration file errors

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -112,12 +112,12 @@ Describe "Validate-Configuration" -Tag 'Unit' {
             $config = Get-DefaultConfiguration
             $config['notesdestpath'] = $null
 
-            { $config | Validate-Configuration } | Should -Throw 'Missing configuration option'
+            { $config | Validate-Configuration } | Should -Throw 'Missing or invalid configuration option'
 
             $config = Get-DefaultConfiguration
             $config['notesdestpath']['value'] = $null
 
-            { $config | Validate-Configuration } | Should -Throw 'Missing configuration option'
+            { $config | Validate-Configuration } | Should -Throw 'Missing or invalid configuration option'
         }
 
         It "Throws on invalid config option type" {


### PR DESCRIPTION
Previously if the user did not specify `-ErrorAction Stop` when calling the script, the user might not get a clear error message when there are uncaught exceptions.

Now error handling is improved and error logging is improved. Configuration file syntax errors are also shown to the user.