### PR TITLE
Fix: Fix broken paths for second level page preceded by a third level page preceded by a first level page

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -437,8 +437,8 @@ function Get-FakeOneNoteHierarchyWithEmptySectionGroupsAndSectionsAndPages {
 }
 
 function Get-FakeOneNoteHierarchy {
-    # Sample outerXML of a hierarchy object. Here we have two identical notebooks: 'test' and 'test2' with a simple nested structure, each with 9 pages, in groups of 3:
-    # 1) The 1st, 2nd, 3rd, 4th, 5th in the notebook base
+    # Sample outerXML of a hierarchy object. Here we have two identical notebooks: 'test' and 'test2' with a simple nested structure
+    # 1) The 1st to 8th are in the notebook base. The 6th - 8th pages test a 3rd level page preceded by a 1st level page.
     # 2) A copy of 1), but nested 1 level
     # 3) A copy of 1), but nested 2 levels
     $hierarchy = @'
@@ -446,11 +446,14 @@ function Get-FakeOneNoteHierarchy {
 <one:Notebooks xmlns:one="http://schemas.microsoft.com/office/onenote/2013/onenote">
     <one:Notebook name="test" nickname="test" ID="{38E47DAB-211E-4EC1-85F1-129656A9D2CE}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/" lastModifiedTime="2021-08-06T16:27:58.000Z" color="#ADE792">
         <one:Section name="s0" ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/s0.one" lastModifiedTime="2021-08-06T16:08:25.000Z" color="#8AA8E4">
-            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096991}" name="p0.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:08:25.000Z" pageLevel="1" />
-            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19542261697052950701320178013485171541838441}" name="p0.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
-            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19535140647270019211520151454305551340000401}" name="p0.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:46:36.000Z" pageLevel="3" />
-            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19542261697052950701320178013485171541838442}" name="p0.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
-            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096992}" name="p0.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:08:25.000Z" pageLevel="1" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096990}" name="p0.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:08:25.000Z" pageLevel="1" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096991}" name="p0.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096992}" name="p0.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:46:36.000Z" pageLevel="3" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096993}" name="p0.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096994}" name="p0.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:08:25.000Z" pageLevel="1" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096995}" name="p0.5 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:46:36.000Z" pageLevel="3" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096996}" name="p0.6 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096997}" name="p0.7 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:08:25.000Z" pageLevel="1" />
             </one:Section>
         <one:SectionGroup name="OneNote_RecycleBin" ID="{1298D961-43A6-46E4-81FC-B4FD9F87755C}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/OneNote_RecycleBin/" lastModifiedTime="2021-08-06T16:27:58.000Z" isRecycleBin="true">
             <one:Section name="Deleted Pages" ID="{4E51704F-4F96-4D17-A453-EE11A4BEEBD8}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/OneNote_RecycleBin/OneNote_DeletedPages.one" lastModifiedTime="2021-08-06T15:57:18.000Z" color="#E1E1E1" isInRecycleBin="true" isDeletedPages="true">
@@ -459,30 +462,39 @@ function Get-FakeOneNoteHierarchy {
         </one:SectionGroup>
         <one:SectionGroup name="g0" ID="{9570CCF6-17C2-4DCE-83A0-F58AE8914E29}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/g9/" lastModifiedTime="2021-08-06T15:49:20.000Z">
             <one:Section name="s1" ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/g9/s1.one" lastModifiedTime="2021-08-06T15:49:13.000Z" color="#F5F96F">
-                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E195456188209333946682201130923317421855940917}" name="p1.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:49:13.000Z" pageLevel="1" />
-                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E195456188209333946682201130923317421855940918}" name="p1.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
-                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E195456188209333946682201130923317421855940919}" name="p1.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:44:29.000Z" pageLevel="3" />
-                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E195456188209333946682201130923317421855940920}" name="p1.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
-                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E195456188209333946682201130923317421855940921}" name="p1.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:49:13.000Z" pageLevel="1" />
+                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E1954561882093339466822011309233174218559400}" name="p1.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:49:13.000Z" pageLevel="1" />
+                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E1954561882093339466822011309233174218559401}" name="p1.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
+                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E1954561882093339466822011309233174218559402}" name="p1.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:44:29.000Z" pageLevel="3" />
+                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E1954561882093339466822011309233174218559403}" name="p1.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
+                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E1954561882093339466822011309233174218559404}" name="p1.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:49:13.000Z" pageLevel="1" />
+                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E1954561882093339466822011309233174218559405}" name="p1.5 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:44:29.000Z" pageLevel="3" />
+                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E1954561882093339466822011309233174218559406}" name="p1.6 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
+                <one:Page ID="{BE566C4F-73DC-43BD-AE7A-1954F8B22C2A}{1}{E1954561882093339466822011309233174218559407}" name="p1.7 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:49:13.000Z" pageLevel="1" />
                 </one:Section>
             <one:SectionGroup name="g1" ID="{9FD73490-F779-4556-BEBF-2185A1938883}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/g9/g1/" lastModifiedTime="2021-08-06T15:49:20.000Z">
                 <one:Section name="s2" ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/g9/g1/s2.one" lastModifiedTime="2021-08-06T15:49:20.000Z" color="#ADE792">
-                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E194664865830060382992201186404186651426498715}" name="p2.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
-                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E194664865830060382992201186404186651426498716}" name="p2.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
-                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E194664865830060382992201186404186651426498717}" name="p2.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:45:38.000Z" pageLevel="3" />
-                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E194664865830060382992201186404186651426498718}" name="p2.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
-                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E194664865830060382992201186404186651426498719}" name="p2.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
+                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E1946648658300603829922011864041866514264980}" name="p2.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
+                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E1946648658300603829922011864041866514264981}" name="p2.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
+                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E1946648658300603829922011864041866514264982}" name="p2.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:45:38.000Z" pageLevel="3" />
+                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E1946648658300603829922011864041866514264983}" name="p2.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
+                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E1946648658300603829922011864041866514264984}" name="p2.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
+                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E1946648658300603829922011864041866514264985}" name="p2.5 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:45:38.000Z" pageLevel="3" />
+                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E1946648658300603829922011864041866514264986}" name="p2.6 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
+                    <one:Page ID="{0ED877BC-2887-4FF7-B5D4-394608754507}{1}{E1946648658300603829922011864041866514264987}" name="p2.7 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
                     </one:Section>
             </one:SectionGroup>
         </one:SectionGroup>
     </one:Notebook>
     <one:Notebook name="test2" nickname="test2" ID="{262450BF-461F-4951-92D3-80C3FC76D27B}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test2/" lastModifiedTime="2021-08-06T16:28:08.000Z" color="#91BAAE" isCurrentlyViewed="true">
         <one:Section name="s0" ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test2/s0.one" lastModifiedTime="2021-08-06T16:09:11.000Z" color="#8AA8E4">
-            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E19555114943310877601019666294307688380101014}" name="p0.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:09:11.000Z" pageLevel="1" />
-            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E19555114943310877601019666294307688380101015}" name="p0.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
-            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E19555114943310877601019666294307688380101016}" name="p0.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:46:36.000Z" pageLevel="3" />
-            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E19555114943310877601019666294307688380101017}" name="p0.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
-            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E19555114943310877601019666294307688380101018}" name="p0.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:09:11.000Z" pageLevel="1" />
+            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E1955511494331087760101966629430768838010100}" name="p0.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:09:11.000Z" pageLevel="1" />
+            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E1955511494331087760101966629430768838010101}" name="p0.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
+            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E1955511494331087760101966629430768838010102}" name="p0.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:46:36.000Z" pageLevel="3" />
+            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E1955511494331087760101966629430768838010103}" name="p0.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
+            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E1955511494331087760101966629430768838010104}" name="p0.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:09:11.000Z" pageLevel="1" />
+            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E1955511494331087760101966629430768838010105}" name="p0.5 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:46:36.000Z" pageLevel="3" />
+            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E1955511494331087760101966629430768838010106}" name="p0.6 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
+            <one:Page ID="{F8F6B54D-769A-43DF-9FD0-ED9F51054880}{1}{E1955511494331087760101966629430768838010107}" name="p0.7 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:09:11.000Z" pageLevel="1" />
             </one:Section>
         <one:SectionGroup name="OneNote_RecycleBin" ID="{1908052E-BCA5-491C-AC6D-6A0D0914B94A}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test2/OneNote_RecycleBin/" lastModifiedTime="2021-08-06T16:28:08.000Z" isRecycleBin="true" isCurrentlyViewed="true">
             <one:Section name="Deleted Pages" ID="{E136ED4A-ED9F-4B1B-A562-183C91FF483A}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test2/OneNote_RecycleBin/OneNote_DeletedPages.one" lastModifiedTime="2021-08-06T15:57:46.000Z" color="#E1E1E1" isCurrentlyViewed="true" isInRecycleBin="true" isDeletedPages="true">
@@ -491,19 +503,25 @@ function Get-FakeOneNoteHierarchy {
         </one:SectionGroup>
         <one:SectionGroup name="g0" ID="{12BCC0AF-9077-4795-89B3-92731DA42BF1}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test2/g0/" lastModifiedTime="2021-08-06T15:45:38.000Z">
             <one:Section name="s1" ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test2/g0/s1.one" lastModifiedTime="2021-08-06T15:44:31.000Z" color="#F5F96F">
-                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156731}" name="p1.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:43:18.000Z" pageLevel="1" />
-                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1955860956312733599901975868119645317054981}" name="p1.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
-                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1956839732948790767531946682831100003055561}" name="p1.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:44:29.000Z" pageLevel="3" />
-                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1955860956312733599901975868119645317054982}" name="p1.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
-                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156732}" name="p1.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:43:18.000Z" pageLevel="1" />
+                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156730}" name="p1.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:43:18.000Z" pageLevel="1" />
+                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156731}" name="p1.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
+                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156732}" name="p1.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:44:29.000Z" pageLevel="3" />
+                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156733}" name="p1.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
+                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156734}" name="p1.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:43:18.000Z" pageLevel="1" />
+                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156735}" name="p1.5 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:44:29.000Z" pageLevel="3" />
+                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156736}" name="p1.6 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:44:24.000Z" pageLevel="2" />
+                <one:Page ID="{66C286AD-A732-4921-BFC3-DB419E018FC5}{1}{E1952215876640442054192014463679294726156737}" name="p1.7 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:43:18.000Z" pageLevel="1" />
             </one:Section>
             <one:SectionGroup name="g1" ID="{70DCA046-102D-43B3-A39B-EA8A6B7D7CAF}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test2/g0/g1/" lastModifiedTime="2021-08-06T15:45:38.000Z">
                 <one:Section name="s2" ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test2/g0/g1/s2.one" lastModifiedTime="2021-08-06T15:45:38.000Z" color="#ADE792">
-                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297671}" name="p2.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
-                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1952193260194966589281945646821144837131531}" name="p2.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
-                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1956557557720375793251994010925467554249381}" name="p2.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:45:38.000Z" pageLevel="3" />
-                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1952193260194966589281945646821144837131532}" name="p2.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
-                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297672}" name="p2.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
+                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297670}" name="p2.0 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
+                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297671}" name="p2.1 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
+                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297672}" name="p2.2 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:45:38.000Z" pageLevel="3" />
+                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297673}" name="p2.3 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
+                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297674}" name="p2.4 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
+                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297675}" name="p2.5 test" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:45:38.000Z" pageLevel="3" />
+                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297676}" name="p2.6 test" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:45:37.000Z" pageLevel="2" />
+                    <one:Page ID="{659C0A68-EEC9-454E-AEB6-34AFE4D8C395}{1}{E1950041523555344809591971866755563186297677}" name="p2.7 test" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T15:45:35.000Z" pageLevel="1" />
                 </one:Section>
             </one:SectionGroup>
         </one:SectionGroup>
@@ -729,37 +747,35 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
         }
 
         It "Should get its pagePrefix from its parent page (if any)" {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             $pagePrefixSeparatorChar = [io.path]::DirectorySeparatorChar
-            for ($i = 0; $i -lt $result.Count; $i = $i + 5) { # Test in fives
+            for ($i = 0; $i -lt $result.Count; $i = $i + 8) { # Test in eights
                 $pageCfg1 = $result[$i] # First level page
                 $pageCfg2 = $result[$i + 1] # Second level page preceded by a first level page
                 $pageCfg3 = $result[$i + 2] # Third level page preceded by a second level page
-                $pageCfg4 = $result[$i + 3] # Third level page preceded by a second level page
-                $pageCfg5 = $result[$i + 4] # Third level page preceded by a second level page
+                $pageCfg4 = $result[$i + 3] # Second level page preceded by a third level page
+                $pageCfg5 = $result[$i + 4] # First level page preceded by a second level page
+                $pageCfg6 = $result[$i + 5] # Third level page preceded by a first level page
+                $pageCfg7 = $result[$i + 6] # Second level page preceded by a third level page
+                $pageCfg8 = $result[$i + 7] # First level page preceded by a second level page
 
-                # Test the first level page
                 $pageCfg1['pagePrefix'] | Should -Be ''
-
-                # Test the second level page preceded by a first level page
                 $pageCfg2['pagePrefix'] | Should -Be "$( $pageCfg1['filePathRel'] )$pagePrefixSeparatorChar"
-
-                # Test the third level page preceded by a second level page
                 $pageCfg3['pagePrefix'] | Should -Be "$( $pageCfg2['filePathRel'] )$pagePrefixSeparatorChar"
-
-                # Test the second level page preceded by a third level page
                 $pageCfg4['pagePrefix'] | Should -Be "$( $pageCfg1['filePathRel'] )$pagePrefixSeparatorChar"
 
-                # Test the first level page preceded by a second level page
-                $pageCfg5['pagePrefix'] | Should -Be ''
+                $pageCfg5['pagePrefix'] | Should -Be '' # First level page
+                $pageCfg6['pagePrefix'] | Should -Be "$( $pageCfg5['filePathRel'] )$pagePrefixSeparatorChar" # Third level page preceded by a first level page
+                $pageCfg7['pagePrefix'] | Should -Be "$( $pageCfg5['filePathRel'] )$pagePrefixSeparatorChar" # Second level page preceded by a third level page
+                $pageCfg8['pagePrefix'] | Should -Be '' # First level page
             }
         }
 
@@ -767,7 +783,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 $pageCfg['fileName'] | Should -Match "$( [regex]::Escape($pageCfg['fileExtension']) )$"
@@ -816,7 +832,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 $pageCfg['insertedAttachments'].Count | Should -Be 2
@@ -830,7 +846,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             for ($i = 0; $i -lt $result.Count; $i++) {
                 $count = 0
@@ -890,7 +906,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             # Test the first object
             $pageCfg = $result[0]
@@ -920,39 +936,50 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
-            for ($i = 0; $i -lt $result.Count; $i = $i + 5) { # Test in fives
+            for ($i = 0; $i -lt $result.Count; $i = $i + 8) { # Test in eights
                 $pageCfg1 = $result[$i] # First level page
                 $pageCfg2 = $result[$i + 1] # Second level page preceded by a first level page
                 $pageCfg3 = $result[$i + 2] # Third level page preceded by a second level page
                 $pageCfg4 = $result[$i + 3] # Second level page preceded by a third level page
                 $pageCfg5 = $result[$i + 4] # First level page preceded by a second level page
+                $pageCfg6 = $result[$i + 5] # Third level page preceded by a first level page
+                $pageCfg7 = $result[$i + 6] # Second level page preceded by a third level page
+                $pageCfg8 = $result[$i + 7] # First level page preceded by a second level page
 
-                # Test the first level page
                 Split-Path $pageCfg1['filePathNormal'] -Leaf | Should -Be  $pageCfg1['fileName']
                 Split-Path $pageCfg1['filePathNormal'] -Parent | Should -Be $pageCfg1['fileDirectory']
                 $pageCfg1['levelsPrefix']| Should -Be "$( '../' * ($pageCfg1['levelsFromRoot'] + $pageCfg1['pageLevel'] - 1) )"
 
-                # Test the second level page preceded by a first level page
                 Split-Path $pageCfg2['filePathNormal'] -Leaf | Should -Be  $pageCfg2['fileName']
                 Split-Path $pageCfg2['filePathNormal'] -Parent | Should -Be $pageCfg2['fileDirectory']
                 $pageCfg2['levelsPrefix']| Should -Be "$( '../' * ($pageCfg2['levelsFromRoot'] + $pageCfg2['pageLevel'] - 1) )"
 
-                # Test the third level page preceded by a second level page
                 Split-Path $pageCfg3['filePathNormal'] -Leaf | Should -Be  $pageCfg3['fileName']
                 Split-Path $pageCfg3['filePathNormal'] -Parent | Should -Be $pageCfg3['fileDirectory']
                 $pageCfg3['levelsPrefix']| Should -Be "$( '../' * ($pageCfg3['levelsFromRoot'] + $pageCfg3['pageLevel'] - 1) )"
 
-                # Test the second level page preceded by a third level page
                 Split-Path $pageCfg4['filePathNormal'] -Leaf | Should -Be $pageCfg4['fileName']
                 Split-Path $pageCfg4['filePathNormal'] -Parent | Should -Be $pageCfg4['fileDirectory']
                 $pageCfg4['levelsPrefix']| Should -Be "$( '../' * ($pageCfg4['levelsFromRoot'] + $pageCfg4['pageLevel'] - 1) )"
 
-                # Test the first level page preceded by a second level page
                 Split-Path $pageCfg5['filePathNormal'] -Leaf | Should -Be $pageCfg5['fileName']
                 Split-Path $pageCfg5['filePathNormal'] -Parent | Should -Be $pageCfg5['fileDirectory']
                 $pageCfg5['levelsPrefix']| Should -Be "$( '../' * ($pageCfg5['levelsFromRoot'] + $pageCfg5['pageLevel'] - 1) )"
+
+                Split-Path $pageCfg6['filePathNormal'] -Leaf | Should -Be $pageCfg6['fileName']
+                Split-Path $pageCfg6['filePathNormal'] -Parent | Should -Be $pageCfg6['fileDirectory']
+                $pageCfg6['levelsPrefix']| Should -Be "$( '../' * ($pageCfg6['levelsFromRoot'] + $pageCfg6['pageLevel'] - 1) )"
+
+                Split-Path $pageCfg7['filePathNormal'] -Leaf | Should -Be $pageCfg7['fileName']
+                Split-Path $pageCfg7['filePathNormal'] -Parent | Should -Be $pageCfg7['fileDirectory']
+                $pageCfg7['levelsPrefix']| Should -Be "$( '../' * ($pageCfg7['levelsFromRoot'] + $pageCfg7['pageLevel'] - 1) )"
+
+                # Test the first level page preceded by a second level page
+                Split-Path $pageCfg8['filePathNormal'] -Leaf | Should -Be $pageCfg8['fileName']
+                Split-Path $pageCfg8['filePathNormal'] -Parent | Should -Be $pageCfg8['fileDirectory']
+                $pageCfg8['levelsPrefix']| Should -Be "$( '../' * ($pageCfg8['levelsFromRoot'] + $pageCfg8['pageLevel'] - 1) )"
             }
 
             $params['Config']['prefixFolders']['value'] = 2
@@ -960,44 +987,57 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
-            for ($i = 0; $i -lt $result.Count; $i = $i + 5) { # Test in fives
+            for ($i = 0; $i -lt $result.Count; $i = $i + 8) { # Test in eights
                 $pageCfg1 = $result[$i] # First level page
                 $pageCfg2 = $result[$i + 1] # Second level page preceded by a first level page
                 $pageCfg3 = $result[$i + 2] # Third level page preceded by a second level page
                 $pageCfg4 = $result[$i + 3] # Second level page preceded by a third level page
                 $pageCfg5 = $result[$i + 4] # First level page preceded by a second level page
+                $pageCfg6 = $result[$i + 5] # Third level page preceded by a first level page
+                $pageCfg7 = $result[$i + 6] # Second level page preceded by a third level page
+                $pageCfg8 = $result[$i + 7] # First level page preceded by a second level page
 
-                # Test the first level page
                 Split-Path $pageCfg1['filePathNormal'] -Parent | Should -Be $pageCfg1['fileDirectory']
                 $pageCfg1['filePathRelUnderscore'] | Should -Be "$( $pageCfg1['nameCompat'] )"
                 Split-Path $pageCfg1['filePathNormal'] -Leaf | Should -Be "$( $pageCfg1['filePathRelUnderscore'] ).md"
                 $pageCfg1['levelsPrefix']| Should -Be "$( '../' * ($pageCfg1['levelsFromRoot'] + 1 - 1) )"
 
-                # Test the second level page preceded by a first level page
                 Split-Path $pageCfg2['filePathNormal'] -Parent | Should -Be $pageCfg2['fileDirectory']
                 $pageCfg2['filePathRelUnderscore'] | Should -Be "$( $pageCfg1['nameCompat'] )_$( $pageCfg2['nameCompat'] )"
                 Split-Path $pageCfg2['filePathNormal'] -Leaf | Should -Be "$( $pageCfg2['filePathRelUnderscore'] ).md"
                 $pageCfg2['levelsPrefix']| Should -Be "$( '../' * ($pageCfg2['levelsFromRoot'] + 1 - 1) )"
 
-                # Test the third level page preceded by a second level page
                 Split-Path $pageCfg3['filePathNormal'] -Parent | Should -Be $pageCfg3['fileDirectory']
                 $pageCfg3['filePathRelUnderscore'] | Should -Be "$( $pageCfg1['nameCompat'] )_$( $pageCfg2['nameCompat'] )_$( $pageCfg3['nameCompat'] )"
                 Split-Path $pageCfg3['filePathNormal'] -Leaf | Should -Be "$( $pageCfg3['filePathRelUnderscore'] ).md"
                 $pageCfg3['levelsPrefix']| Should -Be "$( '../' * ($pageCfg3['levelsFromRoot'] + 1 - 1) )"
 
-                # Test the second level page preceded by a third level page
                 Split-Path $pageCfg4['filePathNormal'] -Parent | Should -Be $pageCfg4['fileDirectory']
                 $pageCfg4['filePathRelUnderscore'] | Should -Be "$( $pageCfg1['nameCompat'] )_$( $pageCfg4['nameCompat'] )"
                 Split-Path $pageCfg4['filePathNormal'] -Leaf | Should -Be "$( $pageCfg4['filePathRelUnderscore'] ).md"
                 $pageCfg4['levelsPrefix']| Should -Be "$( '../' * ($pageCfg4['levelsFromRoot'] + 1 - 1) )"
 
-                # Test the first level page preceded by a second level page
                 Split-Path $pageCfg5['filePathNormal'] -Parent | Should -Be $pageCfg5['fileDirectory']
                 $pageCfg5['filePathRelUnderscore'] | Should -Be "$( $pageCfg5['nameCompat'] )"
                 Split-Path $pageCfg5['filePathNormal'] -Leaf | Should -Be "$( $pageCfg5['filePathRelUnderscore'] ).md"
                 $pageCfg5['levelsPrefix']| Should -Be "$( '../' * ($pageCfg5['levelsFromRoot'] + 1 - 1) )"
+
+                Split-Path $pageCfg6['filePathNormal'] -Parent | Should -Be $pageCfg6['fileDirectory']
+                $pageCfg6['filePathRelUnderscore'] | Should -Be "$( $pageCfg5['nameCompat'] )_$( $pageCfg6['nameCompat'] )"
+                Split-Path $pageCfg6['filePathNormal'] -Leaf | Should -Be "$( $pageCfg6['filePathRelUnderscore'] ).md"
+                $pageCfg6['levelsPrefix']| Should -Be "$( '../' * ($pageCfg6['levelsFromRoot'] + 1 - 1) )"
+
+                Split-Path $pageCfg7['filePathNormal'] -Parent | Should -Be $pageCfg7['fileDirectory']
+                $pageCfg7['filePathRelUnderscore'] | Should -Be "$( $pageCfg5['nameCompat'] )_$( $pageCfg7['nameCompat'] )"
+                Split-Path $pageCfg7['filePathNormal'] -Leaf | Should -Be "$( $pageCfg7['filePathRelUnderscore'] ).md"
+                $pageCfg7['levelsPrefix']| Should -Be "$( '../' * ($pageCfg7['levelsFromRoot'] + 1 - 1) )"
+
+                Split-Path $pageCfg8['filePathNormal'] -Parent | Should -Be $pageCfg8['fileDirectory']
+                $pageCfg8['filePathRelUnderscore'] | Should -Be "$( $pageCfg8['nameCompat'] )"
+                Split-Path $pageCfg8['filePathNormal'] -Leaf | Should -Be "$( $pageCfg8['filePathRelUnderscore'] ).md"
+                $pageCfg8['levelsPrefix']| Should -Be "$( '../' * ($pageCfg8['levelsFromRoot'] + 1 - 1) )"
             }
         }
 
@@ -1007,7 +1047,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 Split-Path $pageCfg['fullexportpath'] -Leaf | Should -Be "$( $pageCfg['id'] )-$( $pageCfg['lastModifiedTimeEpoch'] ).docx"
@@ -1018,7 +1058,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 Split-Path $pageCfg['fullexportpath'] -Leaf | Should -Be "$( $pageCfg['pathFromRootCompat'] ).docx"
@@ -1031,7 +1071,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 $pageCfg['mediaParentPath'] | Should -Be $pageCfg['notesBaseDirectory']
@@ -1042,7 +1082,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 $pageCfg['mediaParentPath'] | Should -Be $pageCfg['fileDirectory']
@@ -1055,7 +1095,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 $pageCfg['conversion'] | Should -Be $params['Config']['conversion']['value']
@@ -1068,7 +1108,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 # The first line will be replaced by page header (8 lines)
@@ -1105,7 +1145,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 $fakeMarkdownContent = ''
@@ -1130,7 +1170,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             # The first line will be replaced by page header (8 lines)
             $fakeMarkdownContent = @"
@@ -1173,7 +1213,7 @@ some other text
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 # Mutate
@@ -1207,7 +1247,7 @@ hello world$( [char]0x00A0 )
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 # The first line will be replaced by page header (8 lines)
@@ -1235,7 +1275,7 @@ foo\bar\0
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 # The first line will be replaced by page header (8 lines)
@@ -1264,7 +1304,7 @@ foo\bar\0
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 # The first line will be replaced by page header (8 lines)
@@ -1295,7 +1335,7 @@ foo\bar\0
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 # The first line will be replaced by page header (8 lines)
@@ -1324,7 +1364,7 @@ foo`r`nbar`r`nbaz
             $result = @( New-SectionGroupConversionConfig @params 6>$null )
 
             # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
-            $result.Count | Should -Be 30
+            $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
                 # The first line will be replaced by page header (8 lines)

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -723,7 +723,7 @@ Function New-SectionGroupConversionConfig {
                         $pageCfg['pageLevel'] = $page.pageLevel -as [int]
                         $pageCfg['conversion'] = $config['conversion']['value']
                         $pageCfg['pagePrefix'] = & {
-                            # 9 differences cases.
+                            # 9 different scenarios
                             if ($pageCfg['pageLevel'] -eq 1) {
                                 # 1 -> 1, 2 -> 1, or 3 -> 1
                                 ''
@@ -736,8 +736,13 @@ Function New-SectionGroupConversionConfig {
                                         # 2 -> 2, or 3 -> 3
                                         "$( Split-Path $previousPage['filePathRel'] -Parent )$( [io.path]::DirectorySeparatorChar )"
                                     }else {
-                                        # 3 -> 2
-                                        "$( Split-Path (Split-Path $previousPage['filePathRel'] -Parent) -Parent )$( [io.path]::DirectorySeparatorChar )"
+                                        # 3 -> 2 (or 4 -> 2, but 4th level subpages don't exist, but technically this supports it)
+                                        $split = $previousPage['filePathRel'].Split([io.path]::DirectorySeparatorChar)
+                                        $index = $pageCfg['pageLevel'] - 1 - 1 # If page level n, the prefix should be n-1
+                                        if ($index -lt 0) {
+                                            $index = 0 # The shallowest subpage must be a child of a first level page, i.e. $split[0]
+                                        }
+                                        "$( $split[0..$index] -join [io.path]::DirectorySeparatorChar )$( [io.path]::DirectorySeparatorChar )"
                                     }
                                 }else {
                                     '' # Should never end up here


### PR DESCRIPTION
Fixes #96

The scenario of 'second level page preceded by a third level page preceded by a first level page' can cause a double `Split-Path -Parent` which should only involve a single `Split-Path -Parent`. Because `['pagePrefix']` ended up with a value of `\`, when `[io.path]::combine` involves any path that begins with `\`, the path immediately begins with `\`, which is an invalid path in Windows.

The determination of the `['pagePrefix']` is now fixed for this particular scenario of 'second level page preceded by a third level page preceded by a first level page'. Unit tests have been added so this fix should work reliably.