### PR TITLE
Feature (configuration): Add `exportPdf` option to include a `.pdf` export alongside `.md` file

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -1389,6 +1389,47 @@ foo`r`nbar`r`nbaz
             }
         }
 
+        It "Should honor config exportPdf" {
+            $params['Config']['exportPdf']['value'] = 2
+
+            $result = @( New-SectionGroupConversionConfig @params 6>$null )
+
+            # 15 pages from 'test' notebook, 15 pages from 'test2' notebook
+            $result.Count | Should -Be 48
+
+            foreach ($pageCfg in $result) {
+                $pageCfg['pdfExportFilePath'] | Should -Be ($pageCfg['FilePath'] -replace '\.md$', '.pdf')
+            }
+
+            # 5 notes, each with very long names
+            $fakeHierarchy = @'
+<?xml version="1.0"?>
+<one:Notebooks xmlns:one="http://schemas.microsoft.co1m/office/onenote/2013/onenote">
+    <one:Notebook name="test" nickname="test" ID="{38E47DAB-211E-4EC1-85F1-129656A9D2CE}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/" lastModifiedTime="2021-08-06T16:27:58.000Z" color="#ADE792">
+        <one:Section name="s0" ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{B0}" path="https://d.docs.live.net/741e69cc14cf9571/Skydrive Notebooks/test/s0.one" lastModifiedTime="2021-08-06T16:08:25.000Z" color="#8AA8E4">
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096991}" name="Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:08:25.000Z" pageLevel="1" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19542261697052950701320178013485171541838441}" name="Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19535140647270019211520151454305551340000401}" name="Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name" dateTime="2021-08-06T15:38:03.000Z" lastModifiedTime="2021-08-06T15:46:36.000Z" pageLevel="3" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19542261697052950701320178013485171541838442}" name="Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name" dateTime="2021-08-06T15:36:14.000Z" lastModifiedTime="2021-08-06T15:38:01.000Z" pageLevel="2" />
+            <one:Page ID="{3D017C7D-F890-4AC8-A094-DEC1163E7B85}{1}{E19461971475288592555920101886406896686096992}" name="Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name Some long name" dateTime="2021-08-06T15:36:33.000Z" lastModifiedTime="2021-08-06T16:08:25.000Z" pageLevel="1" />
+        </one:Section>
+    </one:Notebook>
+</one:Notebooks>
+'@ -as [xml]
+            $params['SectionGroups'] = $fakeHierarchy.Notebooks.Notebook
+            $params['Config']['mdFileNameAndFolderNameMaxLength']['value'] = 100
+            $params['Config']['exportPdf']['value'] = 2
+
+            $result = @( New-SectionGroupConversionConfig @params 6>$null )
+
+            # 5 pages from 'test' notebook
+            $result.Count | Should -Be 5
+
+            foreach ($pageCfg in $result) {
+                $pageCfg['pdfExportFilePath'] | Should -Be ($pageCfg['FilePath'] -replace '.\.md$', '.pdf') # 1 character from the basename should have been trimmed when replacing the extension with '.pdf'
+            }
+        }
+
         It "-AsArray should construct a full Section Group conversion configuration object, based on a given Section Group XML object. Ignores pages in recycle bin." {
             $params['AsArray'] = $true
 
@@ -1472,8 +1513,34 @@ Describe 'Convert-OneNotePage' -Tag 'Unit' {
             }
             Mock Remove-Item {}
             Mock Remove-Item -ParameterFilter { $LiteralPath -and $Force } {}
-            function Publish-OneNotePageToDocx{}
-            Mock Publish-OneNotePageToDocx {}
+            function Publish-OneNotePage {
+                param (
+                    [Parameter(Mandatory)]
+                    [ValidateNotNullOrEmpty()]
+                    [object]
+                    $OneNoteConnection
+                ,
+                    [Parameter(Mandatory)]
+                    [ValidateNotNullOrEmpty()]
+                    [string]
+                    $PageId
+                ,
+                    [Parameter(Mandatory)]
+                    [ValidateNotNullOrEmpty()]
+                    [string]
+                    $Destination
+                ,
+                    [Parameter(Mandatory)]
+                    [ValidateSet('pfOneNotePackage', 'pfOneNotePackage', 'pfOneNote ', 'pfPDF', 'pfXPS', 'pfWord', 'pfEMF', 'pfHTML', 'pfOneNote2007')]
+                    [ValidateNotNullOrEmpty()]
+                    [string]
+                    $PublishFormat
+                )
+            }
+            Mock Publish-OneNotePage {}
+            Mock Publish-OneNotePage -ParameterFilter { $PublishFormat -eq 'pfWord' } {}
+            Mock Publish-OneNotePage -ParameterFilter { $PublishFormat -eq 'pfPdf' } {}
+
             Mock Start-Process {
                 [pscustomobject]@{
                     ExitCode = 0
@@ -1578,15 +1645,25 @@ Describe 'Convert-OneNotePage' -Tag 'Unit' {
         It "Publishes OneNote page to Word" {
             Convert-OneNotePage @params 6>$null
 
-            Assert-MockCalled -CommandName Publish-OneNotePageToDocx -Times 1 -Scope It
+            Assert-MockCalled -CommandName Publish-OneNotePage -ParameterFilter { $PublishFormat -eq 'pfWord' } -Times 1 -Scope It
         }
 
         It "Halts converting if publish OneNote page to Word fails" {
-            Mock Publish-OneNotePageToDocx { throw }
+            Mock Publish-OneNotePage -ParameterFilter { $PublishFormat -eq 'pfWord' } { throw }
 
             $err = Convert-OneNotePage @params 6>$null 2>&1
 
             $err.Exception.Message | Select-Object -First 1 | Should -match 'Failed to convert page'
+        }
+
+        It "Publishes OneNote page to pdf" {
+            $params['Config']['exportPdf']['value'] = 2
+            Mock Move-Item {}
+
+            Convert-OneNotePage @params 6>$null
+
+            Assert-MockCalled -CommandName Publish-OneNotePage -ParameterFilter { $PublishFormat -eq 'pfPdf' } -Times 1 -Scope It
+            Assert-MockCalled -CommandName Move-Item -Times 1 -Scope It
         }
 
         It "Runs pandoc conversion from docx to markdown" {
@@ -1672,7 +1749,7 @@ Describe 'Convert-OneNotePage' -Tag 'Unit' {
         It "Does a dry run" {
             Mock New-Item { 'foo' }
             Mock Remove-Item { 'foo' }
-            Mock Publish-OneNotePageToDocx { 'foo' }
+            Mock Publish-OneNotePage { 'foo' }
             Mock Start-Process { 'foo' }
             Mock Move-Item { 'foo' }
             Mock Get-Content { 'foo' }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The powershell script `ConvertOneNote2MarkDown-v2.ps1` will utilize the OneNote 
 * Allows to choose whether to remove double spaces between bullet points, non-breaking spaces from blank lines, and `>` after bullet lists, which are created when converting with Pandoc
 * Allows to choose whether to remove `\` escape symbol that are created when converting with Pandoc
 * Allows to choose whether to use Line Feed (LF) or Carriage Return + Line Feed (CRLF) for new lines
+* Allows to choose whether to include a `.pdf` export alongside the `.md` file. `.md` does not preserve `InkDrawing` (i.e. overlayed drawings, highlights, pen marks) absolute positions within a page, but a `.pdf` export is a complete page snapshot that preserves `InkDrawing` absolute positions within a page.
 * Allows Detailed logging. Run the script with `-Verbose` to see detailed logs of each page's conversion.
 
 ## Known Issues

--- a/config.example.ps1
+++ b/config.example.ps1
@@ -81,3 +81,8 @@ $keepescape = 1
 # 1: LF (unix) - Default
 # 2: CRLF (windows)
 $newlineCharacter = 1
+
+# Whether to include a PDF export alongside the markdown file
+# 1: Don't include PDF - Default
+# 2: Include PDF
+$exportPdf = 1


### PR DESCRIPTION
Currently, `InkDrawing` (i.e. highlights, pen drawings) absolute positioning of a page is not preserved in the intermediate `.docx`, and hence also not preserved in the final `.md`. One easy solution to preserve the entire state of the page is to use a document that supports absolute positioning - e.g. HTML, PDF. However, HTML export is not an singular HTML file, since images are exported as separate files from the `.htm`.

Hence, a new configuration option `exportPdf` is added, which allows the user to specify whether to include a `.pdf` alongside each `.md` file. `.md` does not preserve `InkDrawing` absolute positions, but a `.pdf` export is a complete page snapshot that also preserves `InkDrawing` positions.