### PR TITLE
Fix: Search recursively for all attachment(s)

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -709,6 +709,7 @@ AAAAAElFTkSuQmCC</one:Data>
                 <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment2[something in brackets].txt" preferredName="attachment2(something in brackets).txt" />
             </one:OE>
         </one:OEChildren>
+        <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment2[something in brackets].txt" preferredName="attachment2(something in brackets).txt" />
     </one:Outline>
 </one:Page>
 '@ -as [xml]

--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -709,8 +709,9 @@ AAAAAElFTkSuQmCC</one:Data>
                 <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment2[something in brackets].txt" preferredName="attachment2(something in brackets).txt" />
             </one:OE>
         </one:OEChildren>
-        <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment2[something in brackets].txt" preferredName="attachment2(something in brackets).txt" />
     </one:Outline>
+    <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment3.txt" preferredName="attachment3.txt" />
+    <one:InsertedFile selected="all" pathCache="C:\Users\LeonardJonathan\AppData\Local\Microsoft\OneNote\16.0\cache\00001BNS.bin" pathSource="C:\Users\LeonardJonathan\Desktop\attachment4.txt" preferredName="attachment4.txt" />
 </one:Page>
 '@ -as [xml]
     $page
@@ -801,10 +802,12 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
             $result.Count | Should -Be 48
 
             foreach ($pageCfg in $result) {
-                $pageCfg['insertedAttachments'].Count | Should -Be 2
+                $pageCfg['insertedAttachments'].Count | Should -Be 4
 
                 $pageCfg['insertedAttachments'][0]['markdownFileName'] | Should -Be 'attachment1\(something-in-brackets\).txt'
                 $pageCfg['insertedAttachments'][1]['markdownFileName'] | Should -Be 'attachment2\(something-in-brackets\).txt'
+                $pageCfg['insertedAttachments'][2]['markdownFileName'] | Should -Be 'attachment3.txt'
+                $pageCfg['insertedAttachments'][3]['markdownFileName'] | Should -Be 'attachment4.txt'
             }
         }
 

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -864,18 +864,22 @@ Function New-SectionGroupConversionConfig {
 
                                 # Get any attachment(s) found in pages
                                 if (Get-Member -InputObject $pagexml -Name 'Page') {
-                                    if (Get-Member -InputObject $pagexml.Page -Name 'Outline') {
-                                        $insertedFiles = $pagexml.Page.Outline.OEChildren.OE | Where-Object { $null -ne $_ -and (Get-Member -InputObject $_ -Name 'InsertedFile') } | ForEach-Object { $_.InsertedFile }
-                                        foreach ($i in $insertedFiles) {
-                                            $attachmentCfg = [ordered]@{}
-                                            $attachmentCfg['object'] =  $i
-                                            $attachmentCfg['nameCompat'] =  $i.preferredName | Remove-InvalidFileNameCharsInsertedFiles
-                                            $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'] | Encode-Markdown -Uri
-                                            $attachmentCfg['source'] =  $i.pathCache
-                                            $attachmentCfg['destination'] =  [io.path]::combine( $pageCfg['mediaPath'], $attachmentCfg['nameCompat'] )
+                                    $insertedFiles = @()
+                                    $insertedFiles += if (Get-Member -InputObject $pagexml.Page -Name 'Outline') {
+                                        $pagexml.Page.Outline.OEChildren.OE | Where-Object { $null -ne $_ -and (Get-Member -InputObject $_ -Name 'InsertedFile') } | ForEach-Object { $_.InsertedFile }
+                                    }
+                                    $insertedFiles += if (Get-Member -InputObject $pagexml.Page -Name 'InsertedFile') {
+                                        $pagexml.Page.InsertedFile
+                                    }
+                                    foreach ($i in $insertedFiles) {
+                                        $attachmentCfg = [ordered]@{}
+                                        $attachmentCfg['object'] =  $i
+                                        $attachmentCfg['nameCompat'] =  $i.preferredName | Remove-InvalidFileNameCharsInsertedFiles
+                                        $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'] | Encode-Markdown -Uri
+                                        $attachmentCfg['source'] =  $i.pathCache
+                                        $attachmentCfg['destination'] =  [io.path]::combine( $pageCfg['mediaPath'], $attachmentCfg['nameCompat'] )
 
-                                            $attachmentCfg
-                                        }
+                                        $attachmentCfg
                                     }
                                 }
                             }

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -864,13 +864,14 @@ Function New-SectionGroupConversionConfig {
 
                                 # Get any attachment(s) found in pages
                                 if (Get-Member -InputObject $pagexml -Name 'Page') {
-                                    $insertedFiles = @()
-                                    $insertedFiles += if (Get-Member -InputObject $pagexml.Page -Name 'Outline') {
-                                        $pagexml.Page.Outline.OEChildren.OE | Where-Object { $null -ne $_ -and (Get-Member -InputObject $_ -Name 'InsertedFile') } | ForEach-Object { $_.InsertedFile }
-                                    }
-                                    $insertedFiles += if (Get-Member -InputObject $pagexml.Page -Name 'InsertedFile') {
-                                        $pagexml.Page.InsertedFile
-                                    }
+                                    $insertedFiles = @(
+                                        if (Get-Member -InputObject $pagexml.Page -Name 'Outline') {
+                                            $pagexml.Page.Outline.OEChildren.OE | Where-Object { $null -ne $_ -and (Get-Member -InputObject $_ -Name 'InsertedFile') } | ForEach-Object { $_.InsertedFile }
+                                        }
+                                        if (Get-Member -InputObject $pagexml.Page -Name 'InsertedFile') {
+                                            $pagexml.Page.InsertedFile
+                                        }
+                                    )
                                     foreach ($i in $insertedFiles) {
                                         $attachmentCfg = [ordered]@{}
                                         $attachmentCfg['object'] =  $i

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -862,26 +862,19 @@ Function New-SectionGroupConversionConfig {
                             & {
                                 $pagexml = Get-OneNotePageContent -OneNoteConnection $OneNoteConnection -PageId $pageCfg['object'].ID
 
-                                # Get any attachment(s) found in pages
-                                if (Get-Member -InputObject $pagexml -Name 'Page') {
-                                    $insertedFiles = @(
-                                        if (Get-Member -InputObject $pagexml.Page -Name 'Outline') {
-                                            $pagexml.Page.Outline.OEChildren.OE | Where-Object { $null -ne $_ -and (Get-Member -InputObject $_ -Name 'InsertedFile') } | ForEach-Object { $_.InsertedFile }
-                                        }
-                                        if (Get-Member -InputObject $pagexml.Page -Name 'InsertedFile') {
-                                            $pagexml.Page.InsertedFile
-                                        }
-                                    )
-                                    foreach ($i in $insertedFiles) {
-                                        $attachmentCfg = [ordered]@{}
-                                        $attachmentCfg['object'] =  $i
-                                        $attachmentCfg['nameCompat'] =  $i.preferredName | Remove-InvalidFileNameCharsInsertedFiles
-                                        $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'] | Encode-Markdown -Uri
-                                        $attachmentCfg['source'] =  $i.pathCache
-                                        $attachmentCfg['destination'] =  [io.path]::combine( $pageCfg['mediaPath'], $attachmentCfg['nameCompat'] )
+                                # Search recursively for all attachment(s). This includes attachments nested in tables etc.
+                                $ns = new-object Xml.XmlNamespaceManager $pagexml.NameTable
+                                $ns.AddNamespace("one", $pagexml.DocumentElement.NamespaceURI)
+                                $insertedFiles = $pagexml.SelectNodes("//one:InsertedFile", $ns)
+                                foreach ($i in $insertedFiles) {
+                                    $attachmentCfg = [ordered]@{}
+                                    $attachmentCfg['object'] =  $i
+                                    $attachmentCfg['nameCompat'] =  $i.preferredName | Remove-InvalidFileNameCharsInsertedFiles
+                                    $attachmentCfg['markdownFileName'] =  $attachmentCfg['nameCompat'] | Encode-Markdown -Uri
+                                    $attachmentCfg['source'] =  $i.pathCache
+                                    $attachmentCfg['destination'] =  [io.path]::combine( $pageCfg['mediaPath'], $attachmentCfg['nameCompat'] )
 
-                                        $attachmentCfg
-                                    }
+                                    $attachmentCfg
                                 }
                             }
                         )


### PR DESCRIPTION
Fixes #117.

Note that I don't really know PowerShell so there very well may be a cleaner / better way to code this.  But AFAICT it does work correctly.