### PR TITLE
Fix (regression): Fix `headerTimestampEnabled` to add a newline between header separator and page content

### DIFF
--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -1127,7 +1127,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
 
                 # Should add only a title, newline, date, newline, separator
                 $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 8
+                $fakeMarkdownContent.Count | Should -Be 9
                 $fakeMarkdownContent[0] | Should -Match '^# .*$'
                 $fakeMarkdownContent[1] | Should -Match '^\s*$'
                 $fakeMarkdownContent[2] -match '^Created: (.+)$' | Should -Be $true
@@ -1142,6 +1142,7 @@ Describe 'New-SectionGroupConversionConfig' -Tag 'Unit' {
                 $fakeMarkdownContent[5] | Should -Match '^\s*$'
                 $fakeMarkdownContent[6] | Should -Be '---'
                 $fakeMarkdownContent[7] | Should -Match '^\s*$'
+                $fakeMarkdownContent[8] | Should -Match '^\s*$'
             }
 
             $params['Config']['headerTimestampEnabled']['value'] = 2
@@ -1202,7 +1203,7 @@ hello world$( [char]0x00A0 )
 
                 # Should remove newlines between bullets, and remove non-breaking spaces. Ignore first 8 lines for page header
                 $split = $mutated -split "`n"
-                $expectedBody = $split[7..($split.Count - 1)] -join "`n"
+                $expectedBody = $split[8..($split.Count - 1)] -join "`n"
                 $expectedBody | Should -Be $( @"
 hello world
 - foo
@@ -1234,7 +1235,7 @@ some other text
 
                 # Should keep newlines between bullets, and keep non-breaking spaces. Ignore first 8 lines for page header
                 $split = $mutated -split "`n"
-                $expectedBody = $split[7..($split.Count - 1)] -join "`n"
+                $expectedBody = $split[8..($split.Count - 1)] -join "`n"
                 $expectedBody | Should -Be $( @"
 hello world$( [char]0x00A0 )
 - foo
@@ -1276,9 +1277,9 @@ foo\bar\0
 
                 # Should remove all backslashes. Ignore first 8 lines for page header
                 $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 9
-                $fakeMarkdownContent[7] | Should -Be 'hello$^*_[]world'
-                $fakeMarkdownContent[8] | Should -Be 'foobar0'
+                $fakeMarkdownContent.Count | Should -Be 10
+                $fakeMarkdownContent[8] | Should -Be 'hello$^*_[]world'
+                $fakeMarkdownContent[9] | Should -Be 'foobar0'
             }
             $params['Config']['keepescape']['value'] = 2
 
@@ -1302,9 +1303,9 @@ foo\bar\0
 
                 # Should remove backslashes that precede non-alphanumeric characters. Ignore first 8 lines for page header
                 $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 9
-                $fakeMarkdownContent[7] | Should -Be 'hello$^\*_[]world'
-                $fakeMarkdownContent[8] | Should -Be 'foo\bar\0'
+                $fakeMarkdownContent.Count | Should -Be 10
+                $fakeMarkdownContent[8] | Should -Be 'hello$^\*_[]world'
+                $fakeMarkdownContent[9] | Should -Be 'foo\bar\0'
             }
 
             $params['Config']['keepescape']['value'] = 3
@@ -1327,11 +1328,11 @@ foo\bar\0
                     }
                 }
 
-                # Should keep backslashes. Ignore first 8 lines for page header
+                # Should keep backslashes. Ignore first  lines for page header
                 $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 9
-                $fakeMarkdownContent[7] | Should -Be 'hello\$\^\\\*\_\[\]world'
-                $fakeMarkdownContent[8] | Should -Be 'foo\bar\0'
+                $fakeMarkdownContent.Count | Should -Be 10
+                $fakeMarkdownContent[8] | Should -Be 'hello\$\^\\\*\_\[\]world'
+                $fakeMarkdownContent[9] | Should -Be 'foo\bar\0'
             }
         }
 
@@ -1355,12 +1356,12 @@ foo`r`nbar`r`nbaz
                     }
                 }
 
-                # Should remove CRs. Ignore first 8 lines for page header
+                # Should remove CRs. Ignore first  lines for page header
                 $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 10
-                $fakeMarkdownContent[7] | Should -Match '^foo$'
-                $fakeMarkdownContent[8] | Should -Match '^bar$'
-                $fakeMarkdownContent[9] | Should -Match '^baz$'`
+                $fakeMarkdownContent.Count | Should -Be 11
+                $fakeMarkdownContent[8] | Should -Match '^foo$'
+                $fakeMarkdownContent[9] | Should -Match '^bar$'
+                $fakeMarkdownContent[10] | Should -Match '^baz$'`
             }
 
             $params['Config']['newlineCharacter']['value'] = 2
@@ -1381,12 +1382,12 @@ foo`r`nbar`r`nbaz
                     }
                 }
 
-                # Should retain CRs. Ignore first 8 lines for page header
+                # Should retain CRs. Ignore first  lines for page header
                 $fakeMarkdownContent = $fakeMarkdownContent -split "`n"
-                $fakeMarkdownContent.Count | Should -Be 10
-                $fakeMarkdownContent[7] | Should -Match "^foo`r$"
-                $fakeMarkdownContent[8] | Should -Match "^bar`r$"
-                $fakeMarkdownContent[9] | Should -Match "^baz$"
+                $fakeMarkdownContent.Count | Should -Be 11
+                $fakeMarkdownContent[8] | Should -Match "^foo`r$"
+                $fakeMarkdownContent[9] | Should -Match "^bar`r$"
+                $fakeMarkdownContent[10] | Should -Match "^baz$"
             }
         }
 

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -912,7 +912,7 @@ Function New-SectionGroupConversionConfig {
                                             if ($config['headerTimestampEnabled']['value'] -eq 1) {
                                                 $heading += "`n`nCreated: $(  $pageCfg['dateTime'].ToString('yyyy-MM-dd HH:mm:ss zz00') )"
                                                 $heading += "`n`nModified: $(  $pageCfg['lastModifiedTime'].ToString('yyyy-MM-dd HH:mm:ss zz00') )"
-                                                $heading += "`n`n---`n"
+                                                $heading += "`n`n---`n`n"
                                             }
                                             $heading
                                         }


### PR DESCRIPTION
Fixes regression in #116. In that PR, a regex incorrectly stripped a newline between the header separator and the page content:

```md
# Title

Created: <timestamp>

Modified: <timestamp>

---
<Page content begins>
```

Now, the header is restored back to `<=v2.17.0` behavior with a new line between the page header and the page content:

```md
# Title

Created: <timestamp>

Modified: <timestamp>

---

<Page content begins>
```