### PR TITLE
Fix (ci): Bump all test jobs to run on `ubuntu-latest`

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -37,7 +37,7 @@ jobs:
   # Docker #
   ##########
   test-powershell-6-0:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/powershell:6.0.2-ubuntu-16.04
     steps:
@@ -50,7 +50,7 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-6-1:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/powershell:6.1.3-ubuntu-18.04
     steps:
@@ -63,7 +63,7 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-6-2:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/powershell:6.2.4-ubuntu-18.04
     steps:
@@ -76,7 +76,7 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-7-0:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
     steps:
@@ -89,7 +89,7 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-7-1:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/powershell:7.1.3-ubuntu-18.04
     steps:
@@ -102,7 +102,7 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-7-2:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/powershell:7.2.0-preview.4-ubuntu-18.04
     steps:


### PR DESCRIPTION
`ubuntu-18.04` is going to be deprecated soon.