### PR TITLE
Enhancement (config): Change `dryRun` config option to a boolean integer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -24,7 +24,7 @@ Describe the unexpected behavior.
 
 ```powershell
 Configuration:
-dryRun: 1
+dryRun: 0
 notesdestpath: C:\temp\notes
 targetNotebook: test
 usedocx: 2

--- a/ConvertOneNote2MarkDown-v2.Tests.ps1
+++ b/ConvertOneNote2MarkDown-v2.Tests.ps1
@@ -40,7 +40,7 @@ Describe "Compile-Configuration" -Tag 'Unit' {
             Mock Get-Content {
                 # Fake content of a config.ps1
                 @'
-$dryrun = 1
+$dryrun = 0
 $notesdestpath = 'c:\temp\notes\/ ' # Deliberately add a trailing slah(es) and space
 $targetNotebook = '   ' # Deliberately add extra spaces
 $usedocx = '1'
@@ -1757,7 +1757,7 @@ Describe 'Convert-OneNotePage' -Tag 'Unit' {
             Mock Get-Content { 'foo' }
             Mock Set-ContentNoBom { 'foo' }
 
-            $params['Config']['DryRun']['value'] = 2
+            $params['Config']['DryRun']['value'] = 1
 
             $result = Convert-OneNotePage @params 6>$null
 

--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -33,12 +33,12 @@ Function Get-DefaultConfiguration {
         dryRun = @{
             description = @'
 Whether to do a dry run
-1: Convert - Default
-2: Convert (dry run)
+0: Convert - Default
+1: Dry run
 '@
-            default = 1
-            value = 1
-            validateRange = 1,2
+            default = 0
+            value = 0
+            validateRange = 0,1
         }
         notesdestpath = @{
             description = @'
@@ -1089,7 +1089,7 @@ Function Convert-OneNotePage {
             foreach ($d in $pageCfg['directoriesToCreate']) {
                 try {
                     "Directory: $( $d )" | Write-Verbose
-                    if ($config['dryRun']['value'] -eq 1) {
+                    if (!$config['dryRun']['value']) {
                         $item = New-Item -Path $d -ItemType Directory -Force -ErrorAction Stop
                     }
                 }catch {
@@ -1101,7 +1101,7 @@ Function Convert-OneNotePage {
                 # Remove any existing docx files, don't proceed if it fails
                 try {
                     "Removing existing docx file: $( $pageCfg['docxExportFilePath'] )" | Write-Verbose
-                    if ($config['dryRun']['value'] -eq 1) {
+                    if (!$config['dryRun']['value']) {
                         if (Test-Path -LiteralPath $pageCfg['docxExportFilePath']) {
                             Remove-Item -LiteralPath $pageCfg['docxExportFilePath'] -Force -ErrorAction Stop
                         }
@@ -1115,7 +1115,7 @@ Function Convert-OneNotePage {
             if (! (Test-Path -LiteralPath $pageCfg['docxExportFilePath']) ) {
                 try {
                     "Publishing new docx file: $( $pageCfg['docxExportFilePath'] )" | Write-Verbose
-                    if ($config['dryRun']['value'] -eq 1) {
+                    if (!$config['dryRun']['value']) {
                         Publish-OneNotePage -OneNoteConnection $OneNoteConnection -PageId $pageCfg['object'].ID -Destination $pageCfg['docxExportFilePath'] -PublishFormat 'pfWord'
                     }
                 }catch {
@@ -1130,7 +1130,7 @@ Function Convert-OneNotePage {
                 if (! (Test-Path -LiteralPath $pageCfg['pdfExportFilePath']) ) {
                     try {
                         "Publishing new pdf file: $( $pageCfg['pdfExportFilePath'] )" | Write-Verbose
-                        if ($config['dryRun']['value'] -eq 1) {
+                        if (!$config['dryRun']['value']) {
                             Publish-OneNotePage -OneNoteConnection $OneNoteConnection -PageId $pageCfg['object'].ID -Destination $pageCfg['pdfExportFilePathTmp'] -PublishFormat 'pfPdf'
                             Move-Item $pageCfg['pdfExportFilePathTmp'] $pageCfg['pdfExportFilePath']
                         }
@@ -1149,7 +1149,7 @@ Function Convert-OneNotePage {
             try {
                 # Start-Process has no way of capturing stderr / stdterr to variables, so we need to use temp files.
                 "Converting docx file to markdown file: $( $pageCfg['filePath'] )" | Write-Verbose
-                if ($config['dryRun']['value'] -eq 1) {
+                if (!$config['dryRun']['value']) {
                     $argumentList = @( '-f', 'docx', '-t', $pageCfg['conversion'], '-i', $pageCfg['docxExportFilePath'], '-o', $pageCfg['filePathNormal'], '--wrap=none', '--markdown-headings=atx', "--extract-media=$( $pageCfg['mediaParentPathPandoc'] )" )
                     "Command line: pandoc.exe $argumentList" | Write-Verbose
                     $process = Start-Process -ErrorAction Stop -RedirectStandardError $stderrFile -PassThru -NoNewWindow -Wait -FilePath pandoc.exe -ArgumentList $argumentList # extracts into ./media of the supplied folder
@@ -1170,7 +1170,7 @@ Function Convert-OneNotePage {
             if ($config['keepdocx']['value'] -eq 1) {
                 try {
                     "Removing existing docx file: $( $pageCfg['docxExportFilePath'] )" | Write-Verbose
-                    if ($config['dryRun']['value'] -eq 1) {
+                    if (!$config['dryRun']['value']) {
                         if (Test-Path -LiteralPath $pageCfg['docxExportFilePath']) {
                             Remove-Item -LiteralPath $pageCfg['docxExportFilePath'] -Force -ErrorAction Stop
                         }
@@ -1184,7 +1184,7 @@ Function Convert-OneNotePage {
             foreach ($attachmentCfg in $pageCfg['insertedAttachments']) {
                 try {
                     "Saving inserted attachment: $( $attachmentCfg['destination'] )" | Write-Verbose
-                    if ($config['dryRun']['value'] -eq 1) {
+                    if (!$config['dryRun']['value']) {
                         Copy-Item -Path $attachmentCfg['source'] -Destination $attachmentCfg['destination'] -Force -ErrorAction Stop
                     }
                 }catch {
@@ -1193,7 +1193,7 @@ Function Convert-OneNotePage {
             }
 
             # Rename images to have unique names - NoteName-Image#-HHmmssff.xyz
-            if ($config['dryRun']['value'] -eq 1) {
+            if (!$config['dryRun']['value']) {
                 $images = Get-ChildItem -Path $pageCfg['mediaPathPandoc'] -Recurse -Force -ErrorAction SilentlyContinue
                 foreach ($image in $images) {
                     # Rename Image
@@ -1205,7 +1205,7 @@ Function Convert-OneNotePage {
                         }
                         $newimagePath = [io.path]::combine( $pageCfg['mediaPath'], $newimageName )
                         "Moving image: $( $image.FullName ) to $( $newimagePath )" | Write-Verbose
-                        if ($config['dryRun']['value'] -eq 1) {
+                        if (!$config['dryRun']['value']) {
                             $item = Move-Item -Path "$( $image.FullName )" -Destination $newimagePath -Force -ErrorAction Stop -PassThru
                         }
                     }catch {
@@ -1214,7 +1214,7 @@ Function Convert-OneNotePage {
                     # Change MD file Image filename References
                     try {
                         "Mutation of markdown: Rename image references to unique name. Find '$( $image.Name )', Replacement: '$( $newimageName )'" | Write-Verbose
-                        if ($config['dryRun']['value'] -eq 1) {
+                        if (!$config['dryRun']['value']) {
                             $content = Get-Content -LiteralPath $pageCfg['filePath'] -Raw -ErrorAction Stop # Use -LiteralPath so that characters like '(', ')', '[', ']', '`', "'", '"' are supported. Or else we will get an error "Cannot find path 'xxx' because it does not exist"
                             $content = $content.Replace("$($image.Name)", "$($newimageName)")
                             Set-ContentNoBom -LiteralPath $pageCfg['filePath'] -Value $content -ErrorAction Stop # Use -LiteralPath so that characters like '(', ')', '[', ']', '`', "'", '"' are supported. Or else we will get an error "Cannot find path 'xxx' because it does not exist"
@@ -1227,7 +1227,7 @@ Function Convert-OneNotePage {
 
             # Mutate markdown content
             try {
-                if ($config['dryRun']['value'] -eq 1) {
+                if (!$config['dryRun']['value']) {
                     # Get markdown content
                     $content = @( Get-Content -LiteralPath $pageCfg['filePath'] -ErrorAction Stop ) # Use -LiteralPath so that characters like '(', ')', '[', ']', '`', "'", '"' are supported. Or else we will get an error "Cannot find path 'xxx' because it does not exist"
                     $content = @(
@@ -1246,7 +1246,7 @@ Function Convert-OneNotePage {
                     foreach ($r in $m['replacements']) {
                         try {
                             "Mutation of markdown: $( $m['description'] ). Regex: '$( $r['searchRegex'] )', Replacement: '$( $r['replacement'].Replace("`r", '\r').Replace("`n", '\n') )'" | Write-Verbose
-                            if ($config['dryRun']['value'] -eq 1) {
+                            if (!$config['dryRun']['value']) {
                                 $content = $content -replace $r['searchRegex'], $r['replacement']
                             }
                         }catch {
@@ -1254,7 +1254,7 @@ Function Convert-OneNotePage {
                         }
                     }
                 }
-                if ($config['dryRun']['value'] -eq 1) {
+                if (!$config['dryRun']['value']) {
                     Set-ContentNoBom -LiteralPath $pageCfg['filePath'] -Value $content -ErrorAction Stop # Use -LiteralPath so that characters like '(', ')', '[', ']', '`', "'", '"' are supported. Or else we will get an error "Cannot find path 'xxx' because it does not exist"
                 }
             }catch {

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The powershell script `ConvertOneNote2MarkDown-v2.ps1` will utilize the OneNote 
     * Run the macro for each Notebook that is open
 1. It is highly recommended that you use VS Code, and its embedded Powershell terminal, as this allows you to edit and run the script, as well as check the results of the .md output all in one window.
 1. If you prefer to use a configuration file, rename `config.example.ps1` to `config.ps1` and configure options in `config.ps1` to your liking.
-   1. You may like to use `$dryRun = 2` to do a dry run first. This is useful for trying out different settings until you find one you like.
+   1. You may like to use `$dryRun = 1` to do a dry run first. This is useful for trying out different settings until you find one you like.
 1. Whatever you choose, open a PowerShell terminal and navigate to the folder containing the script and run it.
     ```.\ConvertOneNote2MarkDown-v2.ps1```
     * If you would like to see detailed logs about the conversion process, use the `-Verbose` switch:

--- a/config.example.ps1
+++ b/config.example.ps1
@@ -7,9 +7,9 @@
 #   3) Run the main script: ./ConvertOneNote2MarkDown-v2.ps1. Sit back while the script starts converting immediately.
 
 # Whether to do a dry run
-# 1: Convert - Default
-# 2: Convert (dry run)
-$dryRun = 1
+# 0: Convert - Default
+# 1: Dry run
+$dryRun = 0
 
 # Specify folder path that will contain your resulting Notes structure - Default: c:\temp\notes
 $notesdestpath = 'c:\temp\notes'


### PR DESCRIPTION
Previously, `dryRun` config option used integer values `1` and `2`, in order to mirror other non-boolean config options. While it may not be a problem for non-technical users, technical users may find that it makes no sense to have `$dryRun = 1` do an actual conversion, and `$dryRun = 2` do a dry run. It has become apparent that `dryRun` is not more intuitive being an integer.

Now, `dryRun` is changed to a boolean (`0` or `1`). Retaining its integer type keeps it easy to use, rather than using actual boolean values `$true` and `$false` which are difficult to type and error prone. This keeps the `dryRun` config options easy to use for both non-technical users and technical users by not violating the principle of least astonishment. Simply set `$dryRun = 0` to disable dry run, and `$dryRun = 1` to enable dry run.