### PR TITLE
Enhancement: Use full path for `$env:TEMP` instead of the MSDOS 8.3 shortened path

### DIFF
--- a/ConvertOneNote2MarkDown-v2.ps1
+++ b/ConvertOneNote2MarkDown-v2.ps1
@@ -849,7 +849,8 @@ Function New-SectionGroupConversionConfig {
                         $pageCfg['tmpPath'] = & {
                             $dateNs = Get-Date -Format "yyyy-MM-dd-HH-mm-ss-fffffff"
                             if ($env:OS -match 'windows') {
-                                [io.path]::combine($env:TEMP, $cfg['notebookName'], $dateNs)
+                                # Ensure $env:TEMP is not MSDOS 8.3 shortened name, but the actual full path. See: https://superuser.com/questions/1524767/powershell-uses-the-short-8-3-form-for-envtemp
+                                [io.path]::combine((Get-Item $env:TEMP).FullName, $cfg['notebookName'], $dateNs)
                             }else {
                                 [io.path]::combine('/tmp', $cfg['notebookName'], $dateNs)
                             }


### PR DESCRIPTION
Previously, the value of `$env:TEMP` is an MSDOS 8.3 shortened path. For example, the home directory of a Windows user with a long username (E.g. `somelongusername`) is shortened to `C:\users\somelo~1` instead of `C:\users\somelongusername`.

Now, the full path of `$env:TEMP` is used. This improves readability and understandability.

Useful links:
- https://superuser.com/questions/529400/how-does-progra1-path-notation-work
- https://web.archive.org/web/20131206010029/http://support.microsoft.com/kb/142982
- https://superuser.com/questions/348079/how-can-i-find-the-short-path-of-a-windows-directory-file
- https://superuser.com/questions/1524767/powershell-uses-the-short-8-3-form-for-envtemp

Related #167
